### PR TITLE
Fix typos in Sphinx documentation pages

### DIFF
--- a/docs/source/advanced/gradients.rst
+++ b/docs/source/advanced/gradients.rst
@@ -31,7 +31,7 @@ In machine learning, for a function :math:`f(X; \theta)`, it is common practice 
 inputs :math:`X` from the parameters :math:`\theta`.
 Mathematically, this is captured by using a semi-colon to semantically separate one group of arguments from another.
 
-In Objax, we represents this semantic distinction through an object :py:class:`objax.Module`:
+In Objax, we represent this semantic distinction through an object :py:class:`objax.Module`:
 
 * the module parameters :math:`\theta` are object attributes of the form :code:`self.w, ...`
 * the inputs :math:`X` are arguments to the methods such as :code:`def __call__(self, x1, x2, ...):`
@@ -127,7 +127,7 @@ Read first the part about :ref:`Variables and Modules` if you haven't done so ye
                 v.value -= lr * g
 
 In short, :code:`self.refs` keeps a list of references to the network trainable variables :code:`TrainVar`.
-When calling the :code:`__call__` method, the values of the variables gets updated by the SGD method.
+When calling the :code:`__call__` method, the values of the variables get updated by the SGD method.
 
 From this we can demonstrate the training of a classifier::
 

--- a/docs/source/advanced/io.rst
+++ b/docs/source/advanced/io.rst
@@ -48,7 +48,7 @@ descriptor, so another way to save would be::
 
 .. note::
     The advantage of using a filename instead of file handle is that data will be written to a temporary file
-    first and temporary file will be renamed to provided filename only after all data has been written.
+    first and a temporary file will be renamed to provided filename only after all data has been written.
     In the event of the program being killed, this prevents from having truncated files.
     When using a file descriptor the code does not have this protection.
     File descriptors are typically used for unit testing.
@@ -66,7 +66,7 @@ Since the code for loading and saving is very concise, simply looking at it is t
 Checkpointing
 -------------
 
-Checkpointing can be defined as saving a neural network weights during training.
+Checkpointing can be defined as saving neural network weights during training.
 Often checkpointing keeps multiple saves, each from different training steps.
 For space reasons, it's common to keep only the latest-k saves.
 Checkpointing can be used for a variety of purposes:
@@ -100,7 +100,7 @@ Objax provides a simple checkpointing interface called :py:class:`objax.io.Check
 Customized checkpointing
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-The :py:class:`objax.io.Checkpoint` class has some constants that allow to customize its behavior.
+The :py:class:`objax.io.Checkpoint` class has some constants that allow it to customize its behavior.
 You can redefine them for example creating a child class that inherits from Checkpoint.
 The fields are the following::
 
@@ -124,7 +124,7 @@ Saving a module
     potential risk.
 
 Now that we warned you, let's mention that Objax modules can be pickled
-with `Python's pickle module <https://docs.python.org/3/library/pickle.html>`_ like many others Python objects.
+with `Python's pickle module <https://docs.python.org/3/library/pickle.html>`_ like many other Python objects.
 This can be quite convenient since you can save not only the module's weight, but the module itself.
 
 Let's look at a simple example::

--- a/docs/source/advanced/io.rst
+++ b/docs/source/advanced/io.rst
@@ -48,7 +48,7 @@ descriptor, so another way to save would be::
 
 .. note::
     The advantage of using a filename instead of file handle is that data will be written to a temporary file
-    first and a temporary file will be renamed to provided filename only after all data has been written.
+    first and the temporary file will be renamed to provided filename only after all data has been written.
     In the event of the program being killed, this prevents from having truncated files.
     When using a file descriptor the code does not have this protection.
     File descriptors are typically used for unit testing.

--- a/docs/source/advanced/jit.rst
+++ b/docs/source/advanced/jit.rst
@@ -360,7 +360,7 @@ advanced users nonetheless::
 Output aggregation
 ^^^^^^^^^^^^^^^^^^
 
-Similarly the ouptput :math:`y` of parallel call is reduced using the :code:`reduce` argument.
+Similarly the output :math:`y` of parallel call is reduced using the :code:`reduce` argument.
 The first dimension :math:`d` of :math:`y` is the device dimension and its name comes from the :code:`axis_name`
 argument while by default is simply :code:`"device"`.
 

--- a/docs/source/advanced/variables_and_modules.rst
+++ b/docs/source/advanced/variables_and_modules.rst
@@ -357,7 +357,7 @@ Combining multiple VarCollections is done by using addition::
 
     # We had to specify starting names for each of the var collections since
     # they have variables with the same name. Had we not, a name collision would
-    # have occured since VarCollection is a dictionary that maps names to variables.
+    # have occurred since VarCollection is a dictionary that maps names to variables.
     m1.vars() + m2.vars()  # raises ValueError('Name conflicts...')
 
 Weight sharing

--- a/docs/source/notebooks/Custom_Networks.ipynb
+++ b/docs/source/notebooks/Custom_Networks.ipynb
@@ -1602,7 +1602,7 @@
       "source": [
         "## Training with PyTorch data processing API\n",
         "\n",
-        "One of the pain points for ML researchers/practioners when building a new ML model is the data processing. Here, we demonstrate how to use data processing API of [PyTorch](https://pytorch.org/) to train a model with Objax. Different deep learning library comes with different data processing APIs, and depending on your preference, you can choose an API and easily combine with Objax.\n",
+        "One of the pain points for ML researchers/practitioners when building a new ML model is the data processing. Here, we demonstrate how to use data processing API of [PyTorch](https://pytorch.org/) to train a model with Objax. Different deep learning library comes with different data processing APIs, and depending on your preference, you can choose an API and easily combine with Objax.\n",
         "\n",
         "Similarly, we prepare an `MNIST` dataset and apply the same data preprocessing."
       ]

--- a/docs/source/notebooks/Objax_Basics.ipynb
+++ b/docs/source/notebooks/Objax_Basics.ipynb
@@ -123,7 +123,7 @@
       "source": [
         "## Tensors\n",
         "\n",
-        "Tensors are essentially multi-dimentional arrays. In JAX and Objax tensors can be placed on GPUs or TPUs to accelerate computations.\n",
+        "Tensors are essentially multi-dimensional arrays. In JAX and Objax tensors can be placed on GPUs or TPUs to accelerate computations.\n",
         "\n",
         "Objax relies on the `jax.numpy.ndarray` primitive from JAX to represent tensors. In turn, this primitive has a very similar API to NumPy `ndarray`."
       ]


### PR DESCRIPTION
This looks like an awesome framework! I was following the documentation and noticed some typos that I fixed in this PR.