### PR TITLE
Raise nicer error if parallel can't divide batch by num devices

### DIFF
--- a/examples/classify/semi_supervised/img/libml/augment/core.py
+++ b/examples/classify/semi_supervised/img/libml/augment/core.py
@@ -24,7 +24,7 @@ def cutout(x, w):
     y0 = tf.cast(tf.round(offsets[0] * (tf.cast(s[0], tf.float32) - w)), tf.int32)
     x0 = tf.cast(tf.round(offsets[1] * (tf.cast(s[1], tf.float32) - w)), tf.int32)
     hr, wr = tf.range(s[0])[:, None, None], tf.range(s[1])[None, :, None]
-    mask = tf.cast((hr >= y0) & (hr < y0 + w) & (wr >= x0) & (wr < x0 + w), tf.float32)
+    mask = 1-tf.cast((hr >= y0) & (hr < y0 + w) & (wr >= x0) & (wr < x0 + w), tf.float32)
     return mask * x
 
 

--- a/objax/module.py
+++ b/objax/module.py
@@ -191,6 +191,8 @@ class Parallel(ModuleWrapper):
 
     def device_reshape(self, x: JaxArray) -> JaxArray:
         """Utility to reshape an input array in order to broadcast to multiple devices."""
+        assert x.shape[0]%self.ndevices == 0, f'Must be able to equally divide batch {x.shape} among ' \
+                                              f'{self.ndevices} devices, but does not go equally.'
         return x.reshape((self.ndevices, x.shape[0] // self.ndevices) + x.shape[1:])
 
     def __call__(self, *args):

--- a/objax/module.py
+++ b/objax/module.py
@@ -191,8 +191,8 @@ class Parallel(ModuleWrapper):
 
     def device_reshape(self, x: JaxArray) -> JaxArray:
         """Utility to reshape an input array in order to broadcast to multiple devices."""
-        assert x.shape[0]%self.ndevices == 0, f'Must be able to equally divide batch {x.shape} among ' \
-                                              f'{self.ndevices} devices, but does not go equally.'
+        assert x.shape[0] % self.ndevices == 0, f'Must be able to equally divide batch {x.shape} among ' \
+                                                f'{self.ndevices} devices, but does not go equally.'
         return x.reshape((self.ndevices, x.shape[0] // self.ndevices) + x.shape[1:])
 
     def __call__(self, *args):


### PR DESCRIPTION
If you try and run a parallel module over a batch of examples where the batch shape doesn't divide the number of devices, the code crashes in numpy land. Instead, throw a nicer error message.