### PR TITLE
Attempt to fix https://github.com/google/objax/issues/72

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-sphinx
+sphinx >= 3.0
 sphinx_rtd_theme
 recommonmark
 nbsphinx


### PR DESCRIPTION
sphinx-build that readthedocs uses is 1.8. The one we use locally is 3.2 and can create the documentation as we need it. 