### PR TITLE
Naming manipulation tools to facilitate importing model weights from …

### DIFF
--- a/docs/source/objax/objax.rst
+++ b/docs/source/objax/objax.rst
@@ -228,7 +228,6 @@ Variables
    :inherited-members:
 
 .. autoclass:: VarCollection
-   :members:
 
     Usage example::
 
@@ -259,6 +258,46 @@ Variables
         jit_f = objax.Jit(lambda x: m(x), vc)
 
     For more information and examples, refer to :ref:`VarCollection`.
+
+    .. automethod:: assign
+    .. automethod:: rename
+
+        Renaming entries in a `VarCollection` is a powerful tool that can be used for
+
+        - mapping weights between models that differ slightly.
+        - loading data checkpoints from foreign ML frameworks.
+
+        Usage example::
+
+            import re
+            import objax
+
+            m = objax.nn.Sequential([objax.nn.Linear(2, 3), objax.functional.relu])
+            print(m.vars())
+            # (Sequential)[0](Linear).b        3 (3,)
+            # (Sequential)[0](Linear).w        6 (2, 3)
+            # +Total(2)                        9
+
+            # For example remove modules from the name
+            renamer = objax.util.Renamer([(re.compile('\([^)]+\)'), '')])
+            print(m.vars().rename(renamer))
+            # [0].b                       3 (3,)
+            # [0].w                       6 (2, 3)
+            # +Total(2)                   9
+
+            # One can chain renamers, their syntax is flexible and it can use a string mapping:
+            renamer_all = objax.util.Renamer({'[': '.', ']': ''}, renamer)
+            print(m.vars().rename(renamer_all))
+            # .0.b                        3 (3,)
+            # .0.w                        6 (2, 3)
+            # +Total(2)                   9
+
+
+    .. automethod:: replicate
+    .. automethod:: subset
+    .. automethod:: tensors
+    .. automethod:: update
+
 
 Constants
 ---------

--- a/docs/source/objax/util.rst
+++ b/docs/source/objax/util.rst
@@ -8,16 +8,20 @@ objax.util
 
 .. autosummary::
 
-   EasyDict
-   args_indexes
-   dummy_context_mgr
-   ilog2
-   positional_args_names
-   to_tuple
+    EasyDict
+    Renamer
+    args_indexes
+    dummy_context_mgr
+    ilog2
+    positional_args_names
+    to_tuple
 
 .. autoclass:: EasyDict
     :members:
     :inherited-members:
+
+.. autoclass:: Renamer
+    :members:
 
 .. autofunction:: args_indexes
 

--- a/objax/variable.py
+++ b/objax/variable.py
@@ -24,7 +24,7 @@ import jax.random as jr
 import numpy as np
 
 from objax.typing import JaxArray
-from objax.util import map_to_device
+from objax.util import map_to_device, Renamer
 
 
 def reduce_mean(x: JaxArray) -> JaxArray:
@@ -245,6 +245,10 @@ class VarCollection(Dict[str, BaseVar]):
             text.append(f'{name:{longest_string}} {size:8d} {v.value.shape}')
         text.append(f'{f"+Total({count})":{longest_string}} {total:8d}')
         return '\n'.join(text)
+
+    def rename(self, renamer: Renamer):
+        """Rename the entries in the VarCollection."""
+        return VarCollection({renamer(k): v for k, v in self.items()})
 
     @contextmanager
     def replicate(self):

--- a/tests/testio.py
+++ b/tests/testio.py
@@ -89,6 +89,17 @@ class TestIO(unittest.TestCase):
         for k, v in m1.vars().items():
             self.assertEqual(v.value.tolist(), v2[k].value.tolist(), msg=f'Variable {k} value is differing.')
 
+    def test_file_load_var_collection_rename(self):
+        a = objax.nn.Conv2D(16, 16, 3)
+        b = objax.nn.Conv2D(16, 16, 3)
+        self.assertFalse(jn.array_equal(a.w.value, b.w.value))
+        with io.BytesIO() as f:
+            objax.io.save_var_collection(f, a.vars().rename(objax.util.Renamer({'(Conv2D)': '(MyConv2D)'})))
+            f.seek(0)
+            objax.io.load_var_collection(f, b.vars(), renamer=objax.util.Renamer({'(MyConv2D)': '(Conv2D)'}))
+        self.assertEqual(a.w.value.dtype, b.w.value.dtype)
+        self.assertTrue(jn.array_equal(a.w.value, a.w.value))
+
 
 class TestCheckpoint(unittest.TestCase):
     def test_save_load_checkpoint(self):

--- a/tests/util.py
+++ b/tests/util.py
@@ -14,6 +14,7 @@
 
 """Unittests for objax.util."""
 
+import re
 import unittest
 
 import objax
@@ -21,7 +22,6 @@ import objax
 
 class TestUtil(unittest.TestCase):
     def test_easy_dict(self):
-        """Test EasyDict behavior."""
         d = objax.util.EasyDict(a=5, b=6)
         self.assertEqual(d, dict(a=5, b=6))
         self.assertEqual(d, objax.util.EasyDict({'a': 5, 'b': 6}))
@@ -30,6 +30,40 @@ class TestUtil(unittest.TestCase):
         self.assertEqual(list(d.values()), [5, 6])
         self.assertEqual(list(d.keys()), ['a', 'b'])
         self.assertEqual([d.a, d.b], [5, 6])
+
+    def test_renamer(self):
+        r = objax.util.Renamer({'aa': 'x', 'bb': 'y'})
+        self.assertEqual(r('baab'), 'bxb')
+        self.assertEqual(r('baaab'), 'bxab')
+        self.assertEqual(r('baaaab'), 'bxxb')
+        self.assertEqual(r('abba'), 'aya')
+        self.assertEqual(r('acca'), 'acca')
+
+        def my_rename(x):
+            return x.replace('aa', 'x').replace('bb', 'y')
+
+        r = objax.util.Renamer(my_rename)
+        self.assertEqual(r('baab'), 'bxb')
+        self.assertEqual(r('baaab'), 'bxab')
+        self.assertEqual(r('baaaab'), 'bxxb')
+        self.assertEqual(r('abba'), 'aya')
+        self.assertEqual(r('acca'), 'acca')
+
+        r = objax.util.Renamer([(re.compile('a{2}'), 'x'), (re.compile('bb'), 'y')])
+        self.assertEqual(r('baab'), 'bxb')
+        self.assertEqual(r('baaab'), 'bxab')
+        self.assertEqual(r('baaaab'), 'bxxb')
+        self.assertEqual(r('abba'), 'aya')
+        self.assertEqual(r('acca'), 'acca')
+
+        r = objax.util.Renamer([(re.compile('(a)(a)'), 'x'), (re.compile('bb'), 'y')])
+        self.assertEqual(r('baab'), 'bxb')
+
+        r = objax.util.Renamer([(re.compile('a{2}'), 'x'), (re.compile('xa'), 'y')])
+        self.assertEqual(r('baaab'), 'byb')
+
+        r = objax.util.Renamer({'aa': 'x'}, chain=objax.util.Renamer({'xa': 'y'}))
+        self.assertEqual(r('baaab'), 'byb')
 
     def test_args_indexes(self):
         """Test args_indexes"""


### PR DESCRIPTION
…other frameworks and to remap weights between models.

- VarCollection has a new rename method to rename its variables.
- load_var_collection has new option to rename variables from the data read from the file.
- Renamer allows to take a dictionary of strings {source:target}, or a tuple (regex, replacement) or a function (str -> str).

Resolves #42