### PR TITLE
Minor changes to documentation.

### DIFF
--- a/docs/source/_static/objax.js
+++ b/docs/source/_static/objax.js
@@ -1,3 +1,5 @@
 document.addEventListener("DOMContentLoaded", function () {
-    document.body.innerHTML = document.body.innerHTML.replace(/<\/em>[\n^<]*em>/g, '').replace(/Union\[jax\.numpy\.lax_numpy\.ndarray, jax.interpreters\.xla\.DeviceArray]/g, 'objax.JaxArray');
+    document.body.innerHTML = document.body.innerHTML
+            .replace(/<\/em>[\n^<]*em>/g, '')
+            .replace(/Union\[jax\.numpy\.lax_numpy\.ndarray, jax.interpreters\.xla\.DeviceArray(, jax\.interpreters\.pxla\.ShardedDeviceArray)?]/g, 'objax.JaxArray');
 });

--- a/docs/source/objax/objax.rst
+++ b/docs/source/objax/objax.rst
@@ -182,7 +182,7 @@ Modules
             y = para_m(x)
 
     For more information, refer to :ref:`Parallelism`.
-    Also note that one can pass variables to be used by Jit for a module `m`: the rest will be optimized away as
+    Also note that one can pass variables to be used by Parallel for a module `m`: the rest will be optimized away as
     constants, for more information refer to :ref:`Constant optimization`.
 
 .. autoclass:: Vectorize

--- a/docs/source/objax/objax.rst
+++ b/docs/source/objax/objax.rst
@@ -161,6 +161,8 @@ Modules
         jit_f = objax.Jit(lambda x: m(x), m.vars())   # Jit a function: provide vars it uses
 
     For more information, refer to :ref:`JIT Compilation`.
+    Also note that one can pass variables to be used by Jit for a module `m`: the rest will be optimized away as
+    constants, for more information refer to :ref:`Constant optimization`.
 
 .. autoclass:: Parallel
    :members: vars
@@ -180,6 +182,8 @@ Modules
             y = para_m(x)
 
     For more information, refer to :ref:`Parallelism`.
+    Also note that one can pass variables to be used by Jit for a module `m`: the rest will be optimized away as
+    constants, for more information refer to :ref:`Constant optimization`.
 
 .. autoclass:: Vectorize
    :members: vars


### PR DESCRIPTION
- Clarify Jit/Parallel use of variables for a module.
- Use JaxArray in docs (rather than its aliased value).

Fixes #78, resolves #79