### PR TITLE
Add warning message if restoring from empty path

### DIFF
--- a/objax/io/checkpoint.py
+++ b/objax/io/checkpoint.py
@@ -92,6 +92,8 @@ class Checkpoint:
         if idx is None:
             all_ckpts = glob.glob(os.path.join(self.logdir, self.DIR_NAME, self.FILE_MATCH))
             if not all_ckpts:
+                if self.verbose:
+                    print('WARNING: Empty path provided; not restoring from any checkpoint.')
                 return 0, ''
             idx = self.checkpoint_idx(max(all_ckpts))
         ckpt = os.path.join(self.logdir, self.DIR_NAME, self.FILE_FORMAT % idx)

--- a/objax/io/checkpoint.py
+++ b/objax/io/checkpoint.py
@@ -93,7 +93,7 @@ class Checkpoint:
             all_ckpts = glob.glob(os.path.join(self.logdir, self.DIR_NAME, self.FILE_MATCH))
             if not all_ckpts:
                 if self.verbose:
-                    print('WARNING: Empty path provided; not restoring from any checkpoint.')
+                    print('No checkpoints found. Skipping restoring variables.')
                 return 0, ''
             idx = self.checkpoint_idx(max(all_ckpts))
         ckpt = os.path.join(self.logdir, self.DIR_NAME, self.FILE_FORMAT % idx)


### PR DESCRIPTION
If you're not careful, sometimes you pass an incorrect path to the checkpoint directory.

By default, objax will create a new directory and then when you call .restore(), it will silently do nothing.

This PR makes objax warn the user that nothing is going to happen, so they have some hope at debugging what's going on. As with the other print() in the checkpoint class, it only prints if verbose is enabled.