### PR TITLE
Give better error message when calling Parallel() without replicate()

### DIFF
--- a/objax/io/checkpoint.py
+++ b/objax/io/checkpoint.py
@@ -92,6 +92,8 @@ class Checkpoint:
         if idx is None:
             all_ckpts = glob.glob(os.path.join(self.logdir, self.DIR_NAME, self.FILE_MATCH))
             if not all_ckpts:
+                if self.verbose:
+                    print('WARNING: Empty path provided; not restoring from any checkpoint.')
                 return 0, ''
             idx = self.checkpoint_idx(max(all_ckpts))
         ckpt = os.path.join(self.logdir, self.DIR_NAME, self.FILE_FORMAT % idx)

--- a/objax/io/checkpoint.py
+++ b/objax/io/checkpoint.py
@@ -93,7 +93,7 @@ class Checkpoint:
             all_ckpts = glob.glob(os.path.join(self.logdir, self.DIR_NAME, self.FILE_MATCH))
             if not all_ckpts:
                 if self.verbose:
-                    print('WARNING: Empty path provided; not restoring from any checkpoint.')
+                    print('No checkpoints found. Skipping restoring variables.')
                 return 0, ''
             idx = self.checkpoint_idx(max(all_ckpts))
         ckpt = os.path.join(self.logdir, self.DIR_NAME, self.FILE_FORMAT % idx)

--- a/objax/module.py
+++ b/objax/module.py
@@ -271,7 +271,8 @@ class Parallel(Module):
         Important: Make sure you call this function within the scope of VarCollection.replicate() statement.
         """
         unreplicated = [k for k, v in self.vc.items() if not isinstance(v.value, (ShardedDeviceArray,
-                                                                                  jax.interpreters.partial_eval.JaxprTracer))]
+                                                                                  jax.interpreters.partial_eval.JaxprTracer,
+                                                                                  jax.interpreters.partial_eval.DynamicJaxprTracer))]
         assert not unreplicated, \
             f'Some variables were not replicated: {unreplicated}.' \
             'did you forget to call VarCollection.replicate on them?'

--- a/objax/module.py
+++ b/objax/module.py
@@ -270,7 +270,7 @@ class Parallel(Module):
         """Call the compiled function or module on multiple devices in parallel.
         Important: Make sure you call this function within the scope of VarCollection.replicate() statement.
         """
-        unreplicated = [k for k, v in self.vc.items() 
+        unreplicated = [k for k, v in self.vc.items()
                         if not isinstance(v.value, (ShardedDeviceArray,
                                                     jax.interpreters.partial_eval.JaxprTracer,
                                                     jax.interpreters.partial_eval.DynamicJaxprTracer))]

--- a/objax/module.py
+++ b/objax/module.py
@@ -270,7 +270,7 @@ class Parallel(Module):
         """Call the compiled function or module on multiple devices in parallel.
         Important: Make sure you call this function within the scope of VarCollection.replicate() statement.
         """
-        unreplicated = [k for k, v in self.vc.items() \
+        unreplicated = [k for k, v in self.vc.items() 
                         if not isinstance(v.value, (ShardedDeviceArray,
                                                     jax.interpreters.partial_eval.JaxprTracer,
                                                     jax.interpreters.partial_eval.DynamicJaxprTracer))]

--- a/objax/module.py
+++ b/objax/module.py
@@ -270,9 +270,10 @@ class Parallel(Module):
         """Call the compiled function or module on multiple devices in parallel.
         Important: Make sure you call this function within the scope of VarCollection.replicate() statement.
         """
-        unreplicated = [k for k, v in self.vc.items() if not isinstance(v.value, (ShardedDeviceArray,
-                                                                                  jax.interpreters.partial_eval.JaxprTracer,
-                                                                                  jax.interpreters.partial_eval.DynamicJaxprTracer))]
+        unreplicated = [k for k, v in self.vc.items() \
+                        if not isinstance(v.value, (ShardedDeviceArray,
+                                                    jax.interpreters.partial_eval.JaxprTracer,
+                                                    jax.interpreters.partial_eval.DynamicJaxprTracer))]
         assert not unreplicated, \
             f'Some variables were not replicated: {unreplicated}.' \
             'did you forget to call VarCollection.replicate on them?'


### PR DESCRIPTION
Currently if you forget to call `replicate()` on a `Parallel` module, it dies somewhere in JaX land in between the 5th and 6th circles of hell. This error makes it possible to understand what's going on and find your way back.