### PR TITLE
Fix parallel test cases to allow floats to be almost zero

### DIFF
--- a/tests/parallel.py
+++ b/tests/parallel.py
@@ -72,7 +72,7 @@ class TestParallel(unittest.TestCase):
             states += [f[1].running_var.value, f[1].running_mean.value]
         f.vars().assign(tensors)
 
-        self.assertEqual(((values[0] - values[1]) ** 2).sum(), 0)
+        self.assertAlmostEqual(((values[0] - values[1]) ** 2).sum(), 0, places=8)
         self.assertGreater(((states[0] - states[2]) ** 2).sum(), 0)
         self.assertGreater(((states[1] - states[3]) ** 2).sum(), 0)
 
@@ -100,7 +100,7 @@ class TestParallel(unittest.TestCase):
             states += [f[1].running_var.value, f[1].running_mean.value]
         f.vars().assign(tensors)
 
-        self.assertEqual(((values[0] - values[1]) ** 2).sum(), 0)
+        self.assertAlmostEqual(((values[0] - values[1]) ** 2).sum(), 0, places=8)
         self.assertGreater(((states[0] - states[2]) ** 2).sum(), 0)
         self.assertGreater(((states[1] - states[3]) ** 2).sum(), 0)
 
@@ -237,7 +237,7 @@ class TestParallel(unittest.TestCase):
             states += [f[1].running_var.value, f[1].running_mean.value]
         f.vars().assign(tensors)
 
-        self.assertEqual(((values[0] - values[1]) ** 2).sum(), 0)
+        self.assertAlmostEqual(((values[0] - values[1]) ** 2).sum(), 0, places=8)
         self.assertGreater(((states[0] - states[2]) ** 2).sum(), 0)
         self.assertGreater(((states[1] - states[3]) ** 2).sum(), 0)
 


### PR DESCRIPTION
When testing #101 I noticed that three parallel tests fail on my machine. All of these are because the value computed is nearly, but not identical, to zero. This PR fixes that.