### PR TITLE
Give error if assigning variable wrong shape

### DIFF
--- a/objax/io/ops.py
+++ b/objax/io/ops.py
@@ -58,9 +58,11 @@ def load_var_collection(file: Union[str, IO[BinaryIO]],
         for name in names:
             index = name_index.get(name)
             if index is not None:
-                v._name = name # make the debugging easier if the assign fails
-                v.assign(jn.array(data[index]))
-                v._name = ""
+                try:
+                    v.assign(jn.array(data[index]))
+                except e:
+                    e.message = f"Error when restoring variable {name}: " + message
+                    raise
                 break
         else:
             misses += names

--- a/objax/io/ops.py
+++ b/objax/io/ops.py
@@ -60,9 +60,8 @@ def load_var_collection(file: Union[str, IO[BinaryIO]],
             if index is not None:
                 try:
                     v.assign(jn.array(data[index]))
-                except e:
-                    e.message = f"Error when restoring variable {name}: " + message
-                    raise
+                except AssertionError as e:
+                    raise AssertionError( f"Error when restoring variable {name}: " + str(e)) from None
                 break
         else:
             misses += names

--- a/objax/io/ops.py
+++ b/objax/io/ops.py
@@ -58,7 +58,9 @@ def load_var_collection(file: Union[str, IO[BinaryIO]],
         for name in names:
             index = name_index.get(name)
             if index is not None:
+                v._name = name # make the debugging easier if the assign fails
                 v.assign(jn.array(data[index]))
+                v._name = ""
                 break
         else:
             misses += names

--- a/objax/variable.py
+++ b/objax/variable.py
@@ -76,11 +76,12 @@ class BaseVar(abc.ABC):
         tensor_device, tensor_shape = shape_and_device(tensor)
         self_device, self_shape = shape_and_device(self.value)
 
-        device_mismatch_error = f"Can not replicate a variable that is currently on {self_device} devices to {tensor_device} devices."
-        assert (tensor_device is None) or (self_device is None) or (self_device == tensor_device) , device_mismatch_error
+        device_mismatch_error = f"Can not replicate a variable that is currently on " \
+                                f"{self_device} devices to {tensor_device} devices."
+        assert (tensor_device is None) or (self_device is None) or (self_device == tensor_device), device_mismatch_error
 
-        shape_mismatch_error = f"Assign can not change shape of variable. The current variable shape is {self_shape}, " \
-                               f"but the requested new shape is {tensor_shape}."
+        shape_mismatch_error = f"Assign can not change shape of variable. The current variable shape is {self_shape}," \
+                               f" but the requested new shape is {tensor_shape}."
         assert tensor_shape == self_shape, shape_mismatch_error
 
 


### PR DESCRIPTION
This PR asserts that the shape of a variable isn't changed when assigning to it. Most of it is fairly uncontroversial (#106).

However I do one further thing. In order for the error message when restoring a variable show the name of the variable that caused the error, I add some additional state to BaseVar to support this. As a result, if restore fails, it won't just say that *some* variable had the wrong shape, but now it will error with exactly *which* variable did.

The other way to do this would be to wrap the restore assign() in a try/catch and then repeat the error, but with the name attached. The benefit of this approach is the error isn't duplicated, but it's a bit more code.

(I also imagine that having the variable name could help for some other errors in the future.)