### PR TITLE
Give a more specific error when loading variables aren't found

### DIFF
--- a/objax/io/ops.py
+++ b/objax/io/ops.py
@@ -54,16 +54,20 @@ def load_var_collection(file: Union[str, IO[BinaryIO]],
             v = v.ref
         name_vars[v].append(k)
     misses = []
+    used_vars = set()
     for v, names in name_vars.items():
         for name in names:
             index = name_index.get(name)
             if index is not None:
+                used_vars.add(name)
                 v.assign(jn.array(data[index]))
                 break
         else:
             misses += names
     if misses:
-        raise ValueError(f'Missing value for variables {misses}')
+        not_used = set(name_index.keys()) - used_vars
+        raise ValueError(f'Missing value for variables currently in the model: {misses}. ' \
+                         f'The following variables on disk were not used, maybe the missing variable was renamed from one of these: {not_used}.')
     if do_close:
         file.close()
 


### PR DESCRIPTION
I always have a hard time with restore() and remembering if it's the model in memory that's wrong, or the checkpoint on disk that's wrong. This makes it very clear and says which is which.