### PR TITLE
Add better error to objax.GradValues function for input_argnums

### DIFF
--- a/objax/gradient.py
+++ b/objax/gradient.py
@@ -61,7 +61,7 @@ class GradValues(Module):
                 self.vc.assign(original_vc)
 
         assert isinstance(input_argnums, tuple) or input_argnums is None, \
-                f'Must pass a tuple of indices to input_argnums; received {input_argnums}.'
+            f'Must pass a tuple of indices to input_argnums; received {input_argnums}.'
         self.input_argnums = input_argnums or tuple()
 
         signature = inspect.signature(f)

--- a/objax/io/checkpoint.py
+++ b/objax/io/checkpoint.py
@@ -90,7 +90,7 @@ class Checkpoint:
             ckpt: full path to the restored checkpoint.
         """
         assert isinstance(vc, VarCollection), \
-            f"Must pass a VarCollection to save; received type {type(vc)}."
+            f'Must pass a VarCollection to restore; received type {type(vc)}.'
         if idx is None:
             all_ckpts = glob.glob(os.path.join(self.logdir, self.DIR_NAME, self.FILE_MATCH))
             if not all_ckpts:

--- a/objax/io/checkpoint.py
+++ b/objax/io/checkpoint.py
@@ -89,6 +89,8 @@ class Checkpoint:
             idx: index of the restored checkpoint.
             ckpt: full path to the restored checkpoint.
         """
+        assert isinstance(vc, VarCollection), \
+            f"Must pass a VarCollection to save; received type {type(vc)}."
         if idx is None:
             all_ckpts = glob.glob(os.path.join(self.logdir, self.DIR_NAME, self.FILE_MATCH))
             if not all_ckpts:
@@ -109,6 +111,8 @@ class Checkpoint:
             vc: variables collection to save.
             idx: index of the new checkpoint where variables should be saved.
         """
+        assert isinstance(vc, VarCollection), \
+            f"Must pass a VarCollection to save; received type {type(vc)}."
         self.SAVE_FN(os.path.join(self.logdir, self.DIR_NAME, self.FILE_FORMAT % idx), vc)
         for ckpt in sorted(glob.glob(os.path.join(self.logdir, self.DIR_NAME, self.FILE_MATCH)))[:-self.keep_ckpts]:
             os.remove(ckpt)

--- a/objax/io/checkpoint.py
+++ b/objax/io/checkpoint.py
@@ -112,7 +112,7 @@ class Checkpoint:
             idx: index of the new checkpoint where variables should be saved.
         """
         assert isinstance(vc, VarCollection), \
-            f"Must pass a VarCollection to save; received type {type(vc)}."
+            f'Must pass a VarCollection to save; received type {type(vc)}.'
         self.SAVE_FN(os.path.join(self.logdir, self.DIR_NAME, self.FILE_FORMAT % idx), vc)
         for ckpt in sorted(glob.glob(os.path.join(self.logdir, self.DIR_NAME, self.FILE_MATCH)))[:-self.keep_ckpts]:
             os.remove(ckpt)


### PR DESCRIPTION
Currently `input_argnums` expects a tuple. If you pass the integer 0, then the `or` treats this as if you passed nothing, and so  it passes an empty tuple and silently does the wrong thing. This fixes that to check the type.