### PR TITLE
Give error if passing the wrong type (e.g., a module) to checkpoint save or restore

### DIFF
--- a/objax/io/checkpoint.py
+++ b/objax/io/checkpoint.py
@@ -110,8 +110,7 @@ class Checkpoint:
             vc: variables collection to save.
             idx: index of the new checkpoint where variables should be saved.
         """
-        assert isinstance(vc, VarCollection), \
-            f"Must pass a VarCollection to save; received type {type(vc)}."
+        assert isinstance(vc, VarCollection), f'Must pass a VarCollection to save; received type {type(vc)}.'
         self.SAVE_FN(os.path.join(self.logdir, self.DIR_NAME, self.FILE_FORMAT % idx), vc)
         for ckpt in sorted(glob.glob(os.path.join(self.logdir, self.DIR_NAME, self.FILE_MATCH)))[:-self.keep_ckpts]:
             os.remove(ckpt)

--- a/objax/io/checkpoint.py
+++ b/objax/io/checkpoint.py
@@ -89,8 +89,7 @@ class Checkpoint:
             idx: index of the restored checkpoint.
             ckpt: full path to the restored checkpoint.
         """
-        assert isinstance(vc, VarCollection), \
-            f"Must pass a VarCollection to save; received type {type(vc)}."
+        assert isinstance(vc, VarCollection), f'Must pass a VarCollection to restore; received type {type(vc)}.'
         if idx is None:
             all_ckpts = glob.glob(os.path.join(self.logdir, self.DIR_NAME, self.FILE_MATCH))
             if not all_ckpts:

--- a/objax/io/checkpoint.py
+++ b/objax/io/checkpoint.py
@@ -89,6 +89,8 @@ class Checkpoint:
             idx: index of the restored checkpoint.
             ckpt: full path to the restored checkpoint.
         """
+        assert isinstance(vc, VarCollection), \
+            f"Must pass a VarCollection to save; received type {type(vc)}."
         if idx is None:
             all_ckpts = glob.glob(os.path.join(self.logdir, self.DIR_NAME, self.FILE_MATCH))
             if not all_ckpts:
@@ -109,6 +111,8 @@ class Checkpoint:
             vc: variables collection to save.
             idx: index of the new checkpoint where variables should be saved.
         """
+        assert isinstance(vc, VarCollection), \
+            f"Must pass a VarCollection to save; received type {type(vc)}."
         self.SAVE_FN(os.path.join(self.logdir, self.DIR_NAME, self.FILE_FORMAT % idx), vc)
         for ckpt in sorted(glob.glob(os.path.join(self.logdir, self.DIR_NAME, self.FILE_MATCH)))[:-self.keep_ckpts]:
             os.remove(ckpt)


### PR DESCRIPTION
Currently if someone accidentally calls save or restore on a module, things crash with an unhelpful error. This gives a better error.