### PR TITLE
Add support on objax.Parallel for list arguments.

### DIFF
--- a/objax/module.py
+++ b/objax/module.py
@@ -278,7 +278,8 @@ class Parallel(Module):
             f'Some variables were not replicated: {unreplicated}.' \
             'did you forget to call VarCollection.replicate on them?'
 
-        args = [x if i in self.static_argnums else jax.tree_map(self.device_reshape, [x])[0] for i, x in enumerate(args)]
+        args = [x if i in self.static_argnums
+                else jax.tree_map(self.device_reshape, [x])[0] for i, x in enumerate(args)]
         output, changes = self._call(self.vc.tensors(), self.vc.subset(RandomState).tensors(), *args)
         self.vc.assign(changes)
         return jax.tree_map(self.reduce, output)

--- a/objax/module.py
+++ b/objax/module.py
@@ -227,7 +227,8 @@ class Parallel(Module):
                  vc: Optional[VarCollection] = None,
                  reduce: Callable[[JaxArray], JaxArray] = jn.concatenate,
                  axis_name: str = 'device',
-                 static_argnums: Optional[Tuple[int, ...]] = None):
+                 static_argnums: Optional[Tuple[int, ...]] = None,
+                 split_args: bool = True):
         """Parallel constructor.
 
         Args:
@@ -237,6 +238,8 @@ class Parallel(Module):
             axis_name: what name to give to the device dimension, used in conjunction with objax.functional.parallel.
             static_argnums: tuple of indexes of f's input arguments to treat as static (constants)).
                 A new graph is compiled for each different combination of values for such inputs.
+            split_args: if True, split non-static arguments along the batch dimension across devices;
+                otherwise, the first dimension of non-static arguments should equal the number of devices.
         """
         if not isinstance(f, Module):
             if vc is None:
@@ -259,6 +262,7 @@ class Parallel(Module):
         self.vc = vc or f.vars()
         self._call = jax.pmap(pmap, axis_name=axis_name, static_broadcasted_argnums=[x + 2 for x in static_argnums])
         self.__wrapped__ = f
+        self.split_args = split_args
 
     def device_reshape(self, x: JaxArray) -> JaxArray:
         """Utility to reshape an input array in order to broadcast to multiple devices."""
@@ -278,7 +282,8 @@ class Parallel(Module):
             f'Some variables were not replicated: {unreplicated}.' \
             'did you forget to call VarCollection.replicate on them?'
 
-        args = [x if i in self.static_argnums else self.device_reshape(x) for i, x in enumerate(args)]
+        if self.split_args:
+            args = [x if i in self.static_argnums else self.device_reshape(x) for i, x in enumerate(args)]
         output, changes = self._call(self.vc.tensors(), self.vc.subset(RandomState).tensors(), *args)
         self.vc.assign(changes)
         return jax.tree_map(self.reduce, output)

--- a/tests/parallel.py
+++ b/tests/parallel.py
@@ -49,24 +49,14 @@ class TestParallel(unittest.TestCase):
         self.assertTrue(jn.array_equal(z1, y))
         self.assertTrue(jn.array_equal(z2, -y))
 
-    def test_parallel_no_split_args_simple(self):
+    def test_parallel_list(self):
         """Parallel inference (concat reduction) without batch splitting."""
         f = objax.nn.Linear(3, 4)
-        x = objax.random.normal((8, 12, 3))
-        y = f(jn.reshape(x, (96, 3)))
-        fp = objax.Parallel(f, split_args=False)
-        with fp.vars().replicate():
-            z = fp(x)
-        self.assertTrue(jn.array_equal(y, z))
-
-    def test_parallel_no_split_args_list(self):
-        """Parallel inference (concat reduction) without batch splitting."""
-        f = objax.nn.Linear(3, 4)
-        g = lambda x: f(x[0]) + f(x[1])
-        x1 = objax.random.normal((8, 12, 3))
-        x2 = objax.random.normal((8, 12, 3))
-        y = g([jn.reshape(x1, (-1, 3)), jn.reshape(x2, (-1, 3))])
-        fp = objax.Parallel(g, vc=f.vars(), split_args=False)
+        g = lambda x: f(x[0]) + x[1][:, jn.newaxis]
+        x1 = objax.random.normal((96, 3))
+        x2 = objax.random.normal((96,))
+        y = g([x1, x2])
+        fp = objax.Parallel(g, vc=f.vars())
         with fp.vars().replicate():
             z = fp([x1, x2])
         self.assertTrue(jn.array_equal(y, z))


### PR DESCRIPTION
The default is True to preserve the behavior of splitting the batch
dimension across devices.

If False, arguments are passed directly to jax.pmap without reshaping.
This supports cases, for example, where an argument is a list of tensors
to be split across devices.