### PR TITLE
Adding support for __repr__, fixes #142

### DIFF
--- a/objax/gradient.py
+++ b/objax/gradient.py
@@ -21,6 +21,7 @@ import jax
 
 from objax.module import Function, Module
 from objax.typing import JaxArray
+from objax.util import repr_function, class_name
 from objax.variable import BaseState, TrainVar, VarCollection
 
 
@@ -37,6 +38,7 @@ class GradValues(Module):
             variables: the variables for which to compute gradients.
             input_argnums: input indexes, if any, on which to compute gradients.
         """
+        self.f = f
         self.vc = variables = VarCollection(variables or ())
         if not isinstance(f, Module):
             f = Function(f, self.vc)
@@ -88,6 +90,9 @@ class GradValues(Module):
         if scope:
             return VarCollection((scope + k, v) for k, v in self.vc.items())
         return VarCollection(self.vc)
+
+    def __repr__(self):
+        return f'{class_name(self)}(f={repr_function(self.f)}, input_argnums={self.input_argnums or None})'
 
 
 class Grad(GradValues):

--- a/objax/nn/layers.py
+++ b/objax/nn/layers.py
@@ -191,7 +191,7 @@ class Conv2D(Module):
 
     def __call__(self, x: JaxArray) -> JaxArray:
         """Returns the results of applying the convolution to input x."""
-        nin = self.w.value.shape[3] * self.groups
+        nin = self.w.value.shape[2] * self.groups
         assert x.shape[1] == nin, (f'Attempting to convolve an input with {x.shape[1]} input channels '
                                    f'when the convolution expects {nin} channels. For reference, '
                                    f'self.w.value.shape={self.w.value.shape} and x.shape={x.shape}.')

--- a/objax/nn/layers.py
+++ b/objax/nn/layers.py
@@ -204,7 +204,7 @@ class Conv2D(Module):
         return y
 
     def __repr__(self):
-        args = dict(nin=self.w.value.shape[2] * self.groups, nout=self.w.value.shape[3], k=self.w.value.shape[:2],
+        args = dict(nin=self.nin, nout=self.w.value.shape[3], k=self.w.value.shape[:2],
                     strides=self.strides, dilations=self.dilations, groups=self.groups, padding=self.padding,
                     use_bias=self.b is not None)
         args = ', '.join(f'{k}={repr(v)}' for k, v in args.items())
@@ -260,7 +260,7 @@ class ConvTranspose2D(Conv2D):
         return y
 
     def __repr__(self):
-        args = dict(nin=self.w.value.shape[2] * self.groups, nout=self.w.value.shape[3], k=self.w.value.shape[:2],
+        args = dict(nin=self.w.value.shape[3], nout=self.nin, k=self.w.value.shape[:2],
                     strides=self.strides, dilations=self.dilations, padding=self.padding,
                     use_bias=self.b is not None)
         args = ', '.join(f'{k}={repr(v)}' for k, v in args.items())

--- a/objax/nn/layers.py
+++ b/objax/nn/layers.py
@@ -247,7 +247,8 @@ class ConvTranspose2D(Conv2D):
             w_init: initializer for convolution kernel (a function that takes in a HWIO shape and returns a 4D matrix).
         """
         super().__init__(nin=nout, nout=nin, k=k, strides=strides, dilations=dilations, padding=padding,
-                         use_bias=use_bias, w_init=w_init)
+                         use_bias=False, w_init=w_init)
+        self.b = TrainVar(jn.zeros((nout, 1, 1))) if use_bias else None
 
     def __call__(self, x: JaxArray) -> JaxArray:
         """Returns the results of applying the transposed convolution to input x."""

--- a/objax/optimizer/adam.py
+++ b/objax/optimizer/adam.py
@@ -21,6 +21,7 @@ from jax import numpy as jn
 from objax import functional
 from objax.module import Module, ModuleList
 from objax.typing import JaxArray
+from objax.util import class_name
 from objax.variable import TrainRef, StateVar, TrainVar, VarCollection
 
 
@@ -64,3 +65,6 @@ class Adam(Module):
             m.value += (1 - beta1) * (g - m.value)
             v.value += (1 - beta2) * (g ** 2 - v.value)
             p.value -= lr * m.value * functional.rsqrt(v.value + self.eps)
+
+    def __repr__(self):
+        return f'{class_name(self)}(beta1={self.beta1}, beta2={self.beta2}, eps={self.eps})'

--- a/objax/optimizer/ema.py
+++ b/objax/optimizer/ema.py
@@ -20,6 +20,7 @@ import jax.numpy as jn
 
 from objax.module import Module, ModuleList
 from objax.typing import JaxArray
+from objax.util import class_name
 from objax.variable import RandomState, TrainRef, StateVar, TrainVar, VarCollection
 
 
@@ -89,3 +90,6 @@ class ExponentialMovingAverage(Module):
             return output
 
         return wrap
+
+    def __repr__(self):
+        return f'{class_name(self)}(momentum={self.momentum}, debias={self.debias}, eps={self.eps})'

--- a/objax/optimizer/lars.py
+++ b/objax/optimizer/lars.py
@@ -20,6 +20,7 @@ import jax.numpy as jn
 
 from objax.module import Module, ModuleList
 from objax.typing import JaxArray
+from objax.util import class_name
 from objax.variable import TrainRef, StateVar, TrainVar, VarCollection
 
 
@@ -67,3 +68,7 @@ class LARS(Module):
             local_lr = lr * jn.maximum(jn.logical_or(p_norm == 0, g_norm == 0), trust_ratio)
             m.value = self.momentum * m.value + local_lr * (g + self.weight_decay * p.value)
             p.value -= m.value
+
+    def __repr__(self):
+        return f'{class_name(self)}(momentum={self.momentum}, weight_decay={self.weight_decay}, ' \
+               f'tc={self.tc}, eps={self.eps})'

--- a/objax/optimizer/momentum.py
+++ b/objax/optimizer/momentum.py
@@ -19,6 +19,7 @@ from typing import List, Optional
 from jax import numpy as jn
 
 from objax.module import Module, ModuleList
+from objax.util import class_name
 from objax.variable import TrainRef, StateVar, TrainVar, VarCollection
 
 
@@ -57,3 +58,6 @@ class Momentum(Module):
             for g, p, m in zip(grads, self.train_vars, self.m):
                 m.value = g + momentum * m.value
                 p.value -= lr * m.value
+
+    def __repr__(self):
+        return f'{class_name(self)}(momentum={self.momentum}, nesterov={self.nesterov})'

--- a/objax/optimizer/sgd.py
+++ b/objax/optimizer/sgd.py
@@ -18,6 +18,7 @@ from typing import List
 
 from objax.module import Module, ModuleList
 from objax.typing import JaxArray
+from objax.util import class_name
 from objax.variable import TrainRef, TrainVar, VarCollection
 
 
@@ -42,3 +43,6 @@ class SGD(Module):
         assert len(grads) == len(self.train_vars), 'Expecting as many gradients as trainable variables'
         for g, p in zip(grads, self.train_vars):
             p.value -= lr * g
+
+    def __repr__(self):
+        return f'{class_name(self)}()'

--- a/objax/privacy/dpsgd/gradient.py
+++ b/objax/privacy/dpsgd/gradient.py
@@ -22,6 +22,7 @@ from objax import random
 from objax.gradient import GradValues
 from objax.module import Module, Vectorize
 from objax.typing import JaxArray
+from objax.util import repr_function, class_name
 from objax.variable import VarCollection
 
 
@@ -61,6 +62,7 @@ class PrivateGradValues(Module):
             idivisor = 1 / jn.maximum(total_grad_norm / l2_norm_clip, 1.)
             return [g * idivisor for g in grads], values
 
+        self.batch_axis = batch_axis
         self.microbatch = microbatch
         self.l2_norm_clip = l2_norm_clip
         self.noise_multiplier = noise_multiplier
@@ -98,3 +100,9 @@ class PrivateGradValues(Module):
         g, v = ([x.mean(0) for x in gv] for gv in (g, v))
         g = [gx + random.normal(gx.shape, stddev=stddev, generator=self.keygen) for gx in g]
         return g, v
+
+    def __repr__(self):
+        args = dict(f=repr_function(self.__wrapped__.f), noise_multiplier=self.noise_multiplier,
+                    l2_norm_clip=self.l2_norm_clip, microbatch=self.microbatch, batch_axis=self.batch_axis)
+        args = ', '.join(f'{k}={v}' for k, v in args.items())
+        return f'{class_name(self)}({args})'

--- a/objax/random/random.py
+++ b/objax/random/random.py
@@ -19,6 +19,7 @@ from typing import Optional, Tuple
 import jax.random as jr
 
 from objax.module import Module
+from objax.util import class_name
 from objax.variable import RandomState, VarCollection
 
 
@@ -51,6 +52,9 @@ class Generator(Module):
     def vars(self, scope: str = '') -> VarCollection:
         self.key  # Make sure the key is created before collecting the vars.
         return super().vars(scope)
+
+    def __repr__(self):
+        return f'{class_name(self)}(seed={self.initial_seed})'
 
 
 DEFAULT_GENERATOR = Generator(0)

--- a/objax/util/util.py
+++ b/objax/util/util.py
@@ -93,6 +93,7 @@ def args_indexes(f: Callable, args: Iterable[str]) -> Iterable[int]:
 
 
 def class_name(x) -> str:
+    """Returns the simplified full name of a class instance."""
     m = x.__class__.__module__
     m = CLASS_MODULES.get(m, m)
     if m.startswith('objax.optimizer'):
@@ -161,13 +162,14 @@ def positional_args_names(f: Callable) -> List[str]:
 
 
 def repr_function(f: Callable) -> str:
+    """Human readable function representation."""
     signature = inspect.signature(f)
     args = [f'{k}={v.default}' for k, v in signature.parameters.items() if v.default is not inspect.Parameter.empty]
     args = ', '.join(args)
     while not hasattr(f, '__name__'):
         if not hasattr(f, 'func'):
             break
-        f = f.func
+        f = f.func  # Handle functools.partial
     if not hasattr(f, '__name__') and hasattr(f, '__class__'):
         return f.__class__.__name__
     if args:

--- a/objax/util/util.py
+++ b/objax/util/util.py
@@ -12,17 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__all__ = ['EasyDict', 'args_indexes', 'dummy_context_mgr', 'ilog2', 'local_kwargs', 'map_to_device',
-           'multi_host_barrier', 'override_args_kwargs', 'positional_args_names', 'Renamer', 'to_padding', 'to_tuple']
+__all__ = ['EasyDict', 'args_indexes', 'class_name', 'dummy_context_mgr', 'ilog2', 'local_kwargs', 'map_to_device',
+           'multi_host_barrier', 'override_args_kwargs', 'positional_args_names', 'Renamer',
+           'repr_function', 'to_padding', 'to_tuple']
 
 import contextlib
 import functools
 import inspect
+import itertools
 import re
 from numbers import Number
 from typing import Callable, List, Union, Tuple, Iterable, Dict, Pattern, Optional, Sequence
 
-import itertools
 import jax
 import jax.numpy as jn
 import numpy as np
@@ -30,6 +31,15 @@ from jax.interpreters.pxla import ShardedDeviceArray
 
 from objax.constants import ConvPadding
 from objax.typing import ConvPaddingInt
+
+CLASS_MODULES = {
+    'objax.dpsgd.gradient': 'objax.dpsgd',
+    'objax.gradient': 'objax',
+    'objax.module': 'objax',
+    'objax.nn.layers': 'objax.nn',
+    'objax.random.random': 'objax.random',
+    'objax.variable': 'objax',
+}
 
 
 class EasyDict(dict):
@@ -80,6 +90,14 @@ def args_indexes(f: Callable, args: Iterable[str]) -> Iterable[int]:
         if index is None:
             raise ValueError(f'Function {f} does not have argument of name {name}', (f, name))
         yield index
+
+
+def class_name(x) -> str:
+    m = x.__class__.__module__
+    m = CLASS_MODULES.get(m, m)
+    if m.startswith('objax.optimizer'):
+        m = 'objax.optimizer'
+    return f'{m}.{x.__class__.__name__}'
 
 
 @contextlib.contextmanager
@@ -140,6 +158,21 @@ def positional_args_names(f: Callable) -> List[str]:
     """Returns the ordered names of the positional arguments of a function."""
     return list(p.name for p in inspect.signature(f).parameters.values()
                 if p.kind in (inspect.Parameter.POSITIONAL_ONLY, inspect.Parameter.POSITIONAL_OR_KEYWORD))
+
+
+def repr_function(f: Callable) -> str:
+    signature = inspect.signature(f)
+    args = [f'{k}={v.default}' for k, v in signature.parameters.items() if v.default is not inspect.Parameter.empty]
+    args = ', '.join(args)
+    while not hasattr(f, '__name__'):
+        if not hasattr(f, 'func'):
+            break
+        f = f.func
+    if not hasattr(f, '__name__') and hasattr(f, '__class__'):
+        return f.__class__.__name__
+    if args:
+        return f'{f.__name__}(*, {args})'
+    return f.__name__
 
 
 def to_padding(padding: Union[ConvPadding, str, ConvPaddingInt], ndim: int) \

--- a/tests/repr.py
+++ b/tests/repr.py
@@ -1,0 +1,140 @@
+import functools
+import unittest
+
+import jax.numpy as jn
+
+import objax
+
+
+class TestRepr(unittest.TestCase):
+    def test_seq(self):
+        r = '\n'.join(['objax.nn.Sequential(',
+                       '  [0] objax.nn.Linear(nin=2, nout=3, use_bias=True, w_init=xavier_normal(*, gain=1))',
+                       '  [1] leaky_relu(*, negative_slope=0.01)',
+                       '  [2] objax.nn.Sequential(',
+                       '    [0] leaky_relu(*, negative_slope=0.5)',
+                       '    [1] objax.nn.Linear(nin=4, nout=5, use_bias=True, w_init=xavier_normal(*, gain=1))',
+                       '  )',
+                       '  [3] tanh',
+                       '  [4] objax.nn.MovingAverage(shape=(2, 3), buffer_size=4, init_value=0.2)',
+                       '  [5] objax.nn.ExponentialMovingAverage(shape=(5, 6), momentum=0.999, init_value=0)',
+                       '  [6] objax.nn.BatchNorm(dims=(3, 4, 5), redux=(1, 7), momentum=0.999, eps=1e-06)',
+                       '  [7] objax.nn.BatchNorm0D(nin=8, momentum=0.999, eps=1e-06)',
+                       '  [8] objax.nn.BatchNorm1D(nin=9, momentum=0.999, eps=1e-06)',
+                       '  [9] objax.nn.BatchNorm2D(nin=19, momentum=0.999, eps=1e-06)',
+                       "  [10] objax.nn.Conv2D(nin=4, nout=5, k=(3, 3), strides=(1, 1), dilations=(1, 1), groups=1,"
+                       " padding='SAME', use_bias=True, w_init=kaiming_normal(*, gain=1))",
+                       "  [11] objax.nn.ConvTranspose2D(nin=5, nout=4, k=(3, 3), strides=(1, 1), dilations=(1, 1),"
+                       " padding='SAME', use_bias=True, w_init=kaiming_normal(*, gain=1))",
+                       '  [12] objax.nn.Dropout(keep=0.7)',
+                       '  [13] objax.nn.SyncedBatchNorm(dims=(3, 4, 5), redux=(1, 7), momentum=0.999, eps=1e-06)',
+                       '  [14] objax.nn.SyncedBatchNorm0D(nin=8, momentum=0.999, eps=1e-06)',
+                       '  [15] objax.nn.SyncedBatchNorm1D(nin=9, momentum=0.999, eps=1e-06)',
+                       '  [16] objax.nn.SyncedBatchNorm2D(nin=19, momentum=0.999, eps=1e-06)',
+                       ')'])
+        m = objax.nn.Sequential([
+            objax.nn.Linear(2, 3),
+            objax.functional.leaky_relu,
+            objax.nn.Sequential([
+                functools.partial(objax.functional.leaky_relu, negative_slope=0.5),
+                objax.nn.Linear(4, 5)]),
+            objax.functional.tanh,
+            objax.nn.MovingAverage((2, 3), 4, 0.2),
+            objax.nn.ExponentialMovingAverage((5, 6)),
+            objax.nn.BatchNorm((3, 4, 5), (1, 7)),
+            objax.nn.BatchNorm0D(8),
+            objax.nn.BatchNorm1D(9),
+            objax.nn.BatchNorm2D(19),
+            objax.nn.Conv2D(4, 5, k=3),
+            objax.nn.ConvTranspose2D(4, 5, k=3),
+            objax.nn.Dropout(0.7),
+            objax.nn.SyncedBatchNorm((3, 4, 5), (1, 7)),
+            objax.nn.SyncedBatchNorm0D(8),
+            objax.nn.SyncedBatchNorm1D(9),
+            objax.nn.SyncedBatchNorm2D(19),
+        ])
+        self.assertEqual(repr(m), r)
+
+    def test_vars(self):
+        t = objax.TrainVar(jn.zeros([1, 2, 3, 2, 1]))
+        tv = '\n'.join(['objax.TrainVar(DeviceArray([[[[[0.],',
+                        '                [0.]],',
+                        '               [[0.],',
+                        '                [0.]],',
+                        '               [[0.],',
+                        '                [0.]]],',
+                        '              [[[0.],',
+                        '                [0.]],',
+                        '               [[0.],',
+                        '                [0.]],',
+                        '               [[0.],',
+                        '                [0.]]]]], dtype=float32), reduce=reduce_mean)'])
+        self.assertEqual(repr(t), tv)
+        r = objax.TrainRef(t)
+        rv = '\n'.join(['objax.TrainRef(ref=objax.TrainVar(DeviceArray([[[[[0.],',
+                        '                [0.]],',
+                        '               [[0.],',
+                        '                [0.]],',
+                        '               [[0.],',
+                        '                [0.]]],',
+                        '              [[[0.],',
+                        '                [0.]],',
+                        '               [[0.],',
+                        '                [0.]],',
+                        '               [[0.],',
+                        '                [0.]]]]], dtype=float32), reduce=reduce_mean))'])
+        self.assertEqual(repr(r), rv)
+        t = objax.StateVar(jn.zeros([1, 2, 3, 2, 1]))
+        tv = '\n'.join(['objax.StateVar(DeviceArray([[[[[0.],',
+                        '                [0.]],',
+                        '               [[0.],',
+                        '                [0.]],',
+                        '               [[0.],',
+                        '                [0.]]],',
+                        '              [[[0.],',
+                        '                [0.]],',
+                        '               [[0.],',
+                        '                [0.]],',
+                        '               [[0.],',
+                        '                [0.]]]]], dtype=float32), reduce=reduce_mean)'])
+        self.assertEqual(repr(t), tv)
+        self.assertEqual(repr(objax.random.Generator().key), 'objax.RandomState(DeviceArray([0, 0], dtype=uint32))')
+
+    def test_random(self):
+        self.assertEqual(repr(objax.random.DEFAULT_GENERATOR), 'objax.random.Generator(seed=0)')
+
+    def test_opt(self):
+        self.assertEqual(repr(objax.optimizer.Adam(objax.VarCollection())),
+                         'objax.optimizer.Adam(beta1=0.9, beta2=0.999, eps=1e-08)')
+        self.assertEqual(repr(objax.optimizer.LARS(objax.VarCollection())),
+                         'objax.optimizer.LARS(momentum=0.9, weight_decay=0.0001, tc=0.001, eps=1e-05)')
+        self.assertEqual(repr(objax.optimizer.Momentum(objax.VarCollection())),
+                         'objax.optimizer.Momentum(momentum=0.9, nesterov=False)')
+        self.assertEqual(repr(objax.optimizer.SGD(objax.VarCollection())),
+                         'objax.optimizer.SGD()')
+        self.assertEqual(repr(objax.optimizer.ExponentialMovingAverage(objax.VarCollection())),
+                         'objax.optimizer.ExponentialMovingAverage(momentum=0.999, debias=False, eps=1e-06)')
+
+    def test_transform(self):
+        def myloss(x):
+            return (x ** 2).mean()
+
+        g = objax.Grad(myloss, variables=objax.VarCollection(), input_argnums=(0,))
+        gv = objax.GradValues(myloss, variables=objax.VarCollection(), input_argnums=(0,))
+        gvp = objax.privacy.dpsgd.PrivateGradValues(myloss, objax.VarCollection(), noise_multiplier=1.,
+                                                    l2_norm_clip=0.5, microbatch=1)
+        self.assertEqual(repr(g), 'objax.Grad(f=myloss, input_argnums=(0,))')
+        self.assertEqual(repr(gv), 'objax.GradValues(f=myloss, input_argnums=(0,))')
+        self.assertEqual(repr(gvp), 'objax.privacy.dpsgd.gradient.PrivateGradValues(f=myloss, noise_multiplier=1.0,'
+                                    ' l2_norm_clip=0.5, microbatch=1, batch_axis=(0,))')
+        self.assertEqual(repr(objax.Jit(gv)),
+                         'objax.Jit(f=objax.GradValues(f=myloss, input_argnums=(0,)), static_argnums=None)')
+        self.assertEqual(repr(objax.Jit(myloss, vc=objax.VarCollection())),
+                         'objax.Jit(f=objax.Function(f=myloss), static_argnums=None)')
+        self.assertEqual(repr(objax.Parallel(gv)),
+                         "objax.Parallel(f=objax.GradValues(f=myloss, input_argnums=(0,)),"
+                         " reduce=concatenate(*, axis=0), axis_name='device', static_argnums=None)")
+        self.assertEqual(repr(objax.Vectorize(myloss, vc=objax.VarCollection())),
+                         'objax.Vectorize(f=objax.Function(f=myloss), batch_axis=(0,))')
+        self.assertEqual(repr(objax.ForceArgs(gv, training=True, word='hello')),
+                         "objax.ForceArgs(module=GradValues, training=True, word='hello')")

--- a/tests/repr.py
+++ b/tests/repr.py
@@ -101,7 +101,7 @@ class TestRepr(unittest.TestCase):
         self.assertEqual(repr(objax.random.Generator().key), 'objax.RandomState(DeviceArray([0, 0], dtype=uint32))')
 
     def test_random(self):
-        self.assertEqual(repr(objax.random.DEFAULT_GENERATOR), 'objax.random.Generator(seed=0)')
+        self.assertEqual(repr(objax.random.Generator(seed=123)), 'objax.random.Generator(seed=123)')
 
     def test_opt(self):
         self.assertEqual(repr(objax.optimizer.Adam(objax.VarCollection())),

--- a/tests/repr.py
+++ b/tests/repr.py
@@ -24,7 +24,7 @@ class TestRepr(unittest.TestCase):
                        '  [9] objax.nn.BatchNorm2D(nin=19, momentum=0.999, eps=1e-06)',
                        "  [10] objax.nn.Conv2D(nin=4, nout=5, k=(3, 3), strides=(1, 1), dilations=(1, 1), groups=1,"
                        " padding='SAME', use_bias=True, w_init=kaiming_normal(*, gain=1))",
-                       "  [11] objax.nn.ConvTranspose2D(nin=5, nout=4, k=(3, 3), strides=(1, 1), dilations=(1, 1),"
+                       "  [11] objax.nn.ConvTranspose2D(nin=4, nout=5, k=(3, 3), strides=(1, 1), dilations=(1, 1),"
                        " padding='SAME', use_bias=True, w_init=kaiming_normal(*, gain=1))",
                        '  [12] objax.nn.Dropout(keep=0.7)',
                        '  [13] objax.nn.SyncedBatchNorm(dims=(3, 4, 5), redux=(1, 7), momentum=0.999, eps=1e-06)',


### PR DESCRIPTION
See sample below:
```python
import functools

import objax

m = objax.nn.Sequential([
    objax.nn.Linear(2, 3),
    objax.functional.leaky_relu,
    objax.nn.Sequential([
        functools.partial(objax.functional.leaky_relu, negative_slope=0.5),
        objax.nn.Linear(4, 5)]),
    objax.functional.tanh,
    objax.nn.MovingAverage((2, 3), 4, 0.2),
    objax.nn.ExponentialMovingAverage((5, 6)),
    objax.nn.BatchNorm((3, 4, 5), (1, 7)),
    objax.nn.BatchNorm0D(8),
    objax.nn.BatchNorm1D(9),
    objax.nn.BatchNorm2D(19),
    objax.nn.Conv2D(4, 5, k=3),
    objax.nn.ConvTranspose2D(4, 5, k=3),
    objax.nn.Dropout(0.7),
    objax.nn.SyncedBatchNorm((3, 4, 5), (1, 7)),
    objax.nn.SyncedBatchNorm0D(8),
    objax.nn.SyncedBatchNorm1D(9),
    objax.nn.SyncedBatchNorm2D(19),
])
print(m)
```

Output:
```plain
objax.nn.Sequential(
  [0] objax.nn.Linear(nin=2, nout=3, use_bias=True, w_init=xavier_normal(*, gain=1))
  [1] leaky_relu(*, negative_slope=0.01)
  [2] objax.nn.Sequential(
    [0] leaky_relu(*, negative_slope=0.5)
    [1] objax.nn.Linear(nin=4, nout=5, use_bias=True, w_init=xavier_normal(*, gain=1))
  )
  [3] tanh
  [4] objax.nn.MovingAverage(shape=(2, 3), buffer_size=4, init_value=0.2)
  [5] objax.nn.ExponentialMovingAverage(shape=(5, 6), momentum=0.999, init_value=0)
  [6] objax.nn.BatchNorm(dims=(3, 4, 5), redux=(1, 7), momentum=0.999, eps=1e-06)
  [7] objax.nn.BatchNorm0D(nin=8, momentum=0.999, eps=1e-06)
  [8] objax.nn.BatchNorm1D(nin=9, momentum=0.999, eps=1e-06)
  [9] objax.nn.BatchNorm2D(nin=19, momentum=0.999, eps=1e-06)
  [10] objax.nn.Conv2D(nin=4, nout=5, k=(3, 3), strides=(1, 1), dilations=(1, 1), groups=1, padding='SAME', use_bias=True, w_init=kaiming_normal(*, gain=1))
  [11] objax.nn.ConvTranspose2D(nin=5, nout=4, k=(3, 3), strides=(1, 1), dilations=(1, 1), padding='SAME', use_bias=True, w_init=kaiming_normal(*, gain=1))
  [12] objax.nn.Dropout(keep=0.7)
  [13] objax.nn.SyncedBatchNorm(dims=(3, 4, 5), redux=(1, 7), momentum=0.999, eps=1e-06)
  [14] objax.nn.SyncedBatchNorm0D(nin=8, momentum=0.999, eps=1e-06)
  [15] objax.nn.SyncedBatchNorm1D(nin=9, momentum=0.999, eps=1e-06)
  [16] objax.nn.SyncedBatchNorm2D(nin=19, momentum=0.999, eps=1e-06)
)
```