### PR TITLE
Implementing 2 phases DP-SGD

### DIFF
--- a/objax/privacy/dpsgd/gradient.py
+++ b/objax/privacy/dpsgd/gradient.py
@@ -39,7 +39,8 @@ class PrivateGradValues(Module):
                  l2_norm_clip: float,
                  microbatch: int,
                  batch_axis: Tuple[Optional[int], ...] = (0,),
-                 keygen: random.Generator = random.DEFAULT_GENERATOR):
+                 keygen: random.Generator = random.DEFAULT_GENERATOR,
+                 use_norm_accumulation: bool = False):
         """Constructs a PrivateGradValues instance.
 
         Args:
@@ -50,6 +51,9 @@ class PrivateGradValues(Module):
             microbatch: the size of each microbatch.
             batch_axis: the axis to use as batch during vectorization. Should be a tuple of 0s.
             keygen: a Generator for random numbers. Defaults to objax.random.DEFAULT_GENERATOR.
+            use_norm_accumulation: whether to use norm accumulation as a first step to compute the clipped
+              gradients (more details further). This is more memory efficient and often faster when the model
+              is very deep and uses a large batch-size.
         """
         super().__init__()
 
@@ -58,19 +62,91 @@ class PrivateGradValues(Module):
 
         self.__wrapped__ = gv = GradValues(f, vc)
 
-        @Function.with_vars(gv.vars())
-        def clipped_grad(*args):
-            grads, values = gv(*args)
-            total_grad_norm = jn.linalg.norm([jn.linalg.norm(g) for g in grads])
-            idivisor = 1 / jn.maximum(total_grad_norm / l2_norm_clip, 1.)
-            return [g * idivisor for g in grads], values
-
         self.batch_axis = batch_axis
         self.microbatch = microbatch
         self.l2_norm_clip = l2_norm_clip
         self.noise_multiplier = noise_multiplier
         self.keygen = keygen
-        self.private_grad = Vectorize(clipped_grad, batch_axis=batch_axis)
+
+        if use_norm_accumulation:
+            self.clipped_grad = self._make_clipped_grad_fn_norm_accumulation(f, gv, vc)
+        else:
+            self.clipped_grad = self._make_clipped_grad_fn_simple(f, gv, vc)
+
+    def _make_clipped_grad_fn_simple(self, f: Callable, gv: GradValues, vc: VarCollection) -> Callable:
+        """Creates a function that computes gradients clipped per-sample.
+        This algorithm vectorizes the computation of a clipped gradient defined over a single sample.
+
+        Args:
+          f: the function for which to compute gradients.
+          gv: the GradValues object that computes non-clipped gradients.
+          vc: the variables for which to compute gradients.
+
+        Returns:
+          clipped_grad: the function computing the average of gradients clipped per-sample.
+        """
+        @Function.with_vars(gv.vars())
+        def clipped_grad_single_example(*args):
+            grads, values = gv(*args)
+            total_grad_norm = jn.linalg.norm([jn.linalg.norm(g) for g in grads])
+            idivisor = 1 / jn.maximum(total_grad_norm / self.l2_norm_clip, 1.)
+            return [g * idivisor for g in grads], values
+
+        clipped_grad_vectorized = Vectorize(clipped_grad_single_example,
+                                            batch_axis=self.batch_axis)
+
+        def clipped_grad(*args):
+            g, v = clipped_grad_vectorized(*args)
+            g, v = jax.tree_map(functools.partial(jn.mean, axis=0), (g, v))
+            return g, v
+
+        return clipped_grad
+
+    def _make_clipped_grad_fn_norm_accumulation(self, f: Callable, gv: GradValues, vc: VarCollection) -> Callable:
+        """Creates a function that computes gradients clipped per-sample.
+        This algorithm first accumulates the norm of the gradient per sample, and then
+        performs an additional weighted backward pass that is equivalent to per-sample clipping.
+        The accumulation allows jax to free up memory whenever the automatic differentiation engine
+        is done processing a layer. This is more memory efficient and can be faster than the "simple" approach
+        defined above, in particular at large batch-sizes for deep models.
+
+        Reference: https://arxiv.org/abs/2009.03106.
+
+        Args:
+          f: the function for which to compute gradients.
+          gv: the GradValues object that computes non-clipped gradients.
+          vc: the variables for which to compute gradients.
+
+        Returns:
+          clipped_grad: the function computing the average of gradients clipped per-sample.
+        """
+        @Function.with_vars(gv.vars())
+        def grad_norm_fn(*args):
+            grads, values = gv(*args)
+            total_grad_norm = jn.linalg.norm([jn.linalg.norm(g) for g in grads])
+            return total_grad_norm, values
+
+        grad_norm_fn_vectorized = Vectorize(grad_norm_fn, batch_axis=self.batch_axis)
+        loss_fn_vectorized = Vectorize(Function.with_vars(gv.vars())(f), batch_axis=self.batch_axis)
+
+        def weighted_loss_fn(weights, *args):
+            returned = loss_fn_vectorized(*args)
+            # the following assumes that the loss is the first element output by loss_fn_vectorized
+            if isinstance(returned, jn.ndarray):
+                loss_vector = returned
+            else:
+                loss_vector = returned[0]
+            return jn.mean(loss_vector * weights)
+
+        weighted_grad_fn = GradValues(weighted_loss_fn, vc)
+
+        def clipped_grad(*args):
+            grad_norms, values = grad_norm_fn_vectorized(*args)
+            idivisor = 1 / jn.maximum(grad_norms / self.l2_norm_clip, 1.)
+            clipped_grads, _ = weighted_grad_fn(idivisor, *args)
+            return clipped_grads, jax.tree_map(functools.partial(jn.mean, axis=0), values)
+
+        return clipped_grad
 
     def reshape_microbatch(self, x: JaxArray) -> JaxArray:
         """Reshapes examples into microbatches.
@@ -99,8 +175,7 @@ class PrivateGradValues(Module):
         assert batch % self.microbatch == 0
         num_microbatches = batch // self.microbatch
         stddev = self.l2_norm_clip * self.noise_multiplier / num_microbatches
-        g, v = self.private_grad(*[self.reshape_microbatch(x) for x in args])
-        g, v = jax.tree_map(functools.partial(jn.mean, axis=0), (g, v))
+        g, v = self.clipped_grad(*[self.reshape_microbatch(x) for x in args])
         g = [gx + random.normal(gx.shape, stddev=stddev, generator=self.keygen) for gx in g]
         return g, v
 

--- a/tests/gradient.py
+++ b/tests/gradient.py
@@ -478,78 +478,86 @@ class TestPrivateGradValues(unittest.TestCase):
         l2_norm_clip = 1e10
         noise_multiplier = 0
 
-        for microbatch in [1, 10, self.ntrain]:
-            gv_priv = objax.Jit(objax.privacy.dpsgd.PrivateGradValues(self.loss, self.model_vars,
-                                                                      noise_multiplier, l2_norm_clip, microbatch,
-                                                                      batch_axis=(0, 0)))
-            gv = objax.GradValues(self.loss, self.model_vars)
-            g_priv, v_priv = gv_priv(self.data, self.labels)
-            g, v = gv(self.data, self.labels)
+        for use_norm_accumulation in [True, False]:
+            for microbatch in [1, 10, self.ntrain]:
+                gv_priv = objax.Jit(objax.privacy.dpsgd.PrivateGradValues(self.loss, self.model_vars,
+                                                                          noise_multiplier, l2_norm_clip, microbatch,
+                                                                          batch_axis=(0, 0),
+                                                                          use_norm_accumulation=use_norm_accumulation))
+                gv = objax.GradValues(self.loss, self.model_vars)
+                g_priv, v_priv = gv_priv(self.data, self.labels)
+                g, v = gv(self.data, self.labels)
 
-            # Check the shape of the gradient.
-            self.assertEqual(g_priv[0].shape, tuple([self.nclass]))
-            self.assertEqual(g_priv[1].shape, tuple([self.ndim, self.nclass]))
+                # Check the shape of the gradient.
+                self.assertEqual(g_priv[0].shape, tuple([self.nclass]))
+                self.assertEqual(g_priv[1].shape, tuple([self.ndim, self.nclass]))
 
-            # Check if the private gradient is similar to the non-private gradient.
-            np.testing.assert_allclose(g[0], g_priv[0], atol=1e-7)
-            np.testing.assert_allclose(g[1], g_priv[1], atol=1e-7)
-            np.testing.assert_allclose(v_priv[0], self.loss(self.data, self.labels)[0], atol=1e-7)
+                # Check if the private gradient is similar to the non-private gradient.
+                np.testing.assert_allclose(g[0], g_priv[0], atol=1e-7)
+                np.testing.assert_allclose(g[1], g_priv[1], atol=1e-7)
+                np.testing.assert_allclose(v_priv[0], self.loss(self.data, self.labels)[0], atol=1e-7)
 
     def test_private_gradvalues_clipping(self):
         """Test if the gradient norm is within l2_norm_clip."""
         noise_multiplier = 0
         acceptable_float_error = 1e-8
-        for microbatch in [1, 10, self.ntrain]:
-            for l2_norm_clip in [0, 1e-2, 1e-1, 1.0]:
-                gv_priv = objax.Jit(objax.privacy.dpsgd.PrivateGradValues(self.loss, self.model_vars,
-                                                                          noise_multiplier, l2_norm_clip, microbatch,
-                                                                          batch_axis=(0, 0)))
-                g_priv, v_priv = gv_priv(self.data, self.labels)
-                # Get the actual squared norm of the gradient.
-                g_normsquared = sum([np.sum(g ** 2) for g in g_priv])
-                self.assertLessEqual(g_normsquared, l2_norm_clip ** 2 + acceptable_float_error)
-                np.testing.assert_allclose(v_priv[0], self.loss(self.data, self.labels)[0], atol=1e-7)
+        for use_norm_accumulation in [True, False]:
+            for microbatch in [1, 10, self.ntrain]:
+                for l2_norm_clip in [0, 1e-2, 1e-1, 1.0]:
+                    gv_priv = objax.Jit(objax.privacy.dpsgd.PrivateGradValues(
+                        self.loss, self.model_vars,
+                        noise_multiplier, l2_norm_clip, microbatch,
+                        batch_axis=(0, 0),
+                        use_norm_accumulation=use_norm_accumulation))
+                    g_priv, v_priv = gv_priv(self.data, self.labels)
+                    # Get the actual squared norm of the gradient.
+                    g_normsquared = sum([np.sum(g ** 2) for g in g_priv])
+                    self.assertLessEqual(g_normsquared, l2_norm_clip ** 2 + acceptable_float_error)
+                    np.testing.assert_allclose(v_priv[0], self.loss(self.data, self.labels)[0], atol=1e-7)
 
     def test_private_gradvalues_noise(self):
         """Test if the noise std is around expected."""
         runs = 100
         alpha = 0.0001
-        for microbatch in [1, 10, self.ntrain]:
-            for noise_multiplier in [0.1, 10.0]:
-                for l2_norm_clip in [0.01, 0.1]:
-                    gv_priv = objax.Jit(objax.privacy.dpsgd.PrivateGradValues(self.loss,
-                                                                              self.model_vars,
-                                                                              noise_multiplier,
-                                                                              l2_norm_clip,
-                                                                              microbatch,
-                                                                              batch_axis=(0, 0)))
-                    # Repeat the run and collect all gradients.
-                    g_privs = []
-                    for i in range(runs):
-                        g_priv, v_priv = gv_priv(self.data, self.labels)
-                        g_privs.append(np.concatenate([g_n.reshape(-1) for g_n in g_priv]))
-                        np.testing.assert_allclose(v_priv[0], self.loss(self.data, self.labels)[0], atol=1e-7)
-                    g_privs = np.array(g_privs)
+        for use_norm_accumulation in [True, False]:
+            for microbatch in [1, 10, self.ntrain]:
+                for noise_multiplier in [0.1, 10.0]:
+                    for l2_norm_clip in [0.01, 0.1]:
+                        gv_priv = objax.Jit(objax.privacy.dpsgd.PrivateGradValues(
+                            self.loss,
+                            self.model_vars,
+                            noise_multiplier,
+                            l2_norm_clip,
+                            microbatch,
+                            batch_axis=(0, 0),
+                            use_norm_accumulation=use_norm_accumulation))
+                        # Repeat the run and collect all gradients.
+                        g_privs = []
+                        for i in range(runs):
+                            g_priv, v_priv = gv_priv(self.data, self.labels)
+                            g_privs.append(np.concatenate([g_n.reshape(-1) for g_n in g_priv]))
+                            np.testing.assert_allclose(v_priv[0], self.loss(self.data, self.labels)[0], atol=1e-7)
+                        g_privs = np.array(g_privs)
 
-                    # Compute empirical std and expected std.
-                    std_empirical = np.std(g_privs, axis=0, ddof=1)
-                    std_theoretical = l2_norm_clip * noise_multiplier / (self.ntrain // microbatch)
+                        # Compute empirical std and expected std.
+                        std_empirical = np.std(g_privs, axis=0, ddof=1)
+                        std_theoretical = l2_norm_clip * noise_multiplier / (self.ntrain // microbatch)
 
-                    # Conduct chi-square test for correct expected standard
-                    # deviation.
-                    chi2_value = (runs - 1) * std_empirical ** 2 / std_theoretical ** 2
-                    chi2_cdf = chi2.cdf(chi2_value, runs - 1)
-                    self.assertTrue(np.all(alpha <= chi2_cdf) and np.all(chi2_cdf <= 1.0 - alpha))
+                        # Conduct chi-square test for correct expected standard
+                        # deviation.
+                        chi2_value = (runs - 1) * std_empirical ** 2 / std_theoretical ** 2
+                        chi2_cdf = chi2.cdf(chi2_value, runs - 1)
+                        self.assertTrue(np.all(alpha <= chi2_cdf) and np.all(chi2_cdf <= 1.0 - alpha))
 
-                    # Conduct chi-square test for incorrect expected standard
-                    # deviations: expect failure.
-                    chi2_value = (runs - 1) * std_empirical ** 2 / (1.25 * std_theoretical) ** 2
-                    chi2_cdf = chi2.cdf(chi2_value, runs - 1)
-                    self.assertFalse(np.all(alpha <= chi2_cdf) and np.all(chi2_cdf <= 1.0 - alpha))
+                        # Conduct chi-square test for incorrect expected standard
+                        # deviations: expect failure.
+                        chi2_value = (runs - 1) * std_empirical ** 2 / (1.25 * std_theoretical) ** 2
+                        chi2_cdf = chi2.cdf(chi2_value, runs - 1)
+                        self.assertFalse(np.all(alpha <= chi2_cdf) and np.all(chi2_cdf <= 1.0 - alpha))
 
-                    chi2_value = (runs - 1) * std_empirical ** 2 / (0.75 * std_theoretical) ** 2
-                    chi2_cdf = chi2.cdf(chi2_value, runs - 1)
-                    self.assertFalse(np.all(alpha <= chi2_cdf) and np.all(chi2_cdf <= 1.0 - alpha))
+                        chi2_value = (runs - 1) * std_empirical ** 2 / (0.75 * std_theoretical) ** 2
+                        chi2_cdf = chi2.cdf(chi2_value, runs - 1)
+                        self.assertFalse(np.all(alpha <= chi2_cdf) and np.all(chi2_cdf <= 1.0 - alpha))
 
 
 class TestPrivateGradValuesAxis(unittest.TestCase):
@@ -569,10 +577,11 @@ class TestPrivateGradValuesAxis(unittest.TestCase):
         # Procedure to get private gradient given microbatch and l2_norm_clip.
         noise_multiplier = 0.
 
-        def get_g(microbatch, l2_norm_clip, batch_axis=(0,)):
+        def get_g(microbatch, l2_norm_clip, use_norm_accumulation, batch_axis=(0,)):
             gv_priv = objax.privacy.dpsgd.PrivateGradValues(loss, objax.VarCollection({'w': w}),
                                                             noise_multiplier, l2_norm_clip, microbatch,
-                                                            batch_axis=batch_axis)
+                                                            batch_axis=batch_axis,
+                                                            use_norm_accumulation=use_norm_accumulation)
             g_priv, v_priv = gv_priv(data)
             return g_priv
 
@@ -580,26 +589,28 @@ class TestPrivateGradValuesAxis(unittest.TestCase):
 
     def test_private_gradvalues_axis0(self):
         """Test for batch_axis = (0,) with different microbatch."""
-        # microbatch = 1
-        g_priv = self.get_g(microbatch=1, l2_norm_clip=1.0)
-        grad_expected = -np.array([1, 1, 1, -1, 1, -1], dtype=np.float32).mean()
-        np.testing.assert_allclose(g_priv[0], grad_expected, atol=1e-5, err_msg='microbatch=1')
+        for use_norm_accumulation in [True, False]:
+            # microbatch = 1
+            g_priv = self.get_g(microbatch=1, l2_norm_clip=1.0, use_norm_accumulation=use_norm_accumulation)
+            grad_expected = -np.array([1, 1, 1, -1, 1, -1], dtype=np.float32).mean()
+            np.testing.assert_allclose(g_priv[0], grad_expected, atol=1e-5, err_msg='microbatch=1')
 
-        # microbatch = 6
-        g_priv = self.get_g(microbatch=6, l2_norm_clip=1.0)
-        grad_expected = 0.
-        np.testing.assert_allclose(g_priv[0], grad_expected, atol=1e-5, err_msg='microbatch=6')
+            # microbatch = 6
+            g_priv = self.get_g(microbatch=6, l2_norm_clip=1.0, use_norm_accumulation=use_norm_accumulation)
+            grad_expected = 0.
+            np.testing.assert_allclose(g_priv[0], grad_expected, atol=1e-5, err_msg='microbatch=6')
 
-        # microbatch = 2
-        g_priv = self.get_g(microbatch=2, l2_norm_clip=3.0)
-        grad_expected = -np.array([2.5, -3, 2], dtype=np.float32).mean()  # unclipped gradient is [2.5, -4.5, 2]
-        np.testing.assert_allclose(g_priv[0], grad_expected, atol=1e-5, err_msg='microbatch=2')
+            # microbatch = 2
+            g_priv = self.get_g(microbatch=2, l2_norm_clip=3.0, use_norm_accumulation=use_norm_accumulation)
+            grad_expected = -np.array([2.5, -3, 2], dtype=np.float32).mean()  # unclipped gradient is [2.5, -4.5, 2]
+            np.testing.assert_allclose(g_priv[0], grad_expected, atol=1e-5, err_msg='microbatch=2')
 
     def test_private_gradvalues_axis1(self):
         """Test if batch_axis = (1,) raises ValueError."""
         microbatch = 1
         l2_norm_clip = 1.0
-        self.assertRaises(ValueError, self.get_g, microbatch, l2_norm_clip, (1,))
+        for use_norm_accumulation in [True, False]:
+            self.assertRaises(ValueError, self.get_g, microbatch, l2_norm_clip, use_norm_accumulation, (1,))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR implements a two-phase algorithm for per-sample gradient clipping with the goal of improving memory efficiency for the training of private deep models. The two steps are: (1) accumulate the norms of the gradient per sample and (2) use those norm values to perform a weighted backward pass that is equivalent to per-sample clipping. The user can choose whether to use this new algorithm or the currently implemented one through a boolean argument.

The unit-tests have been adapted to check results for both algorithms.

Let me know if this fits well!