### PR TITLE
Objax variables could be used in place of native JAX arrays

### DIFF
--- a/objax/nn/layers.py
+++ b/objax/nn/layers.py
@@ -199,7 +199,7 @@ class Conv2D(Module):
                                      rhs_dilation=self.dilations,
                                      feature_group_count=self.groups,
                                      dimension_numbers=('NCHW', 'HWIO', 'NCHW'))
-        if self.b:
+        if self.b is not None:
             y += self.b.value
         return y
 
@@ -255,7 +255,7 @@ class ConvTranspose2D(Conv2D):
         y = lax.conv_transpose(x, self.w.value, self.strides, self.padding,
                                rhs_dilation=self.dilations,
                                dimension_numbers=('NCHW', 'HWIO', 'NCHW'), transpose_kernel=True)
-        if self.b:
+        if self.b is not None:
             y += self.b.value
         return y
 
@@ -347,7 +347,7 @@ class Linear(Module):
     def __call__(self, x: JaxArray) -> JaxArray:
         """Returns the results of applying the linear transformation to input x."""
         y = jn.dot(x, self.w.value)
-        if self.b:
+        if self.b is not None:
             y += self.b.value
         return y
 

--- a/objax/optimizer/ema.py
+++ b/objax/optimizer/ema.py
@@ -47,10 +47,10 @@ class ExponentialMovingAverage(Module):
             if isinstance(v, TrainRef):
                 v = v.ref
             if isinstance(v, TrainVar):
-                trainable[v] = True
+                trainable[id(v)] = v
             else:
-                non_trainable[v] = True
-        self.refs = ModuleList(list(non_trainable.keys()) + [TrainRef(v) for v in trainable.keys()])
+                non_trainable[id(v)] = v
+        self.refs = ModuleList(list(non_trainable.values()) + [TrainRef(v) for v in trainable.values()])
         self.m = ModuleList(StateVar(jn.zeros_like(x.value)) for x in self.refs)
 
     def __call__(self):

--- a/objax/variable.py
+++ b/objax/variable.py
@@ -86,13 +86,14 @@ class BaseVar(abc.ABC):
     # __getattr__.
     def __neg__(self): return self.value.__neg__()  # noqa: E704
     def __pos__(self): return self.value.__pos__()  # noqa: E704
+    def __abs__(self): return self.value.__abs__()  # noqa: E704
+    def __invert__(self): return self.value.__invert__()  # noqa: E704
     def __eq__(self, other): return self.value.__eq__(_get_jax_value(other))  # noqa: E704
     def __ne__(self, other): return self.value.__ne__(_get_jax_value(other))  # noqa: E704
     def __lt__(self, other): return self.value.__lt__(_get_jax_value(other))  # noqa: E704
     def __le__(self, other): return self.value.__le__(_get_jax_value(other))  # noqa: E704
     def __gt__(self, other): return self.value.__gt__(_get_jax_value(other))  # noqa: E704
     def __ge__(self, other): return self.value.__ge__(_get_jax_value(other))  # noqa: E704
-    def __abs__(self): return self.value.__abs__()  # noqa: E704
     def __add__(self, other): return self.value.__add__(_get_jax_value(other))  # noqa: E704
     def __radd__(self, other): return self.value.__radd__(_get_jax_value(other))  # noqa: E704
     def __sub__(self, other): return self.value.__sub__(_get_jax_value(other))  # noqa: E704
@@ -119,17 +120,14 @@ class BaseVar(abc.ABC):
     def __ror__(self, other): return self.value.__ror__(_get_jax_value(other))  # noqa: E704
     def __xor__(self, other): return self.value.__xor__(_get_jax_value(other))  # noqa: E704
     def __rxor__(self, other): return self.value.__rxor__(_get_jax_value(other))  # noqa: E704
-    def __invert__(self): return self.value.__invert__()  # noqa: E704
     def __lshift__(self, other): return self.value.__lshift__(_get_jax_value(other))  # noqa: E704
     def __rlshift__(self, other): return self.value.__rlshift__(_get_jax_value(other))  # noqa: E704
     def __rshift__(self, other): return self.value.__rshift__(_get_jax_value(other))  # noqa: E704
     def __rrshift__(self, other): return self.value.__rrshift__(_get_jax_value(other))  # noqa: E704
-    def __int__(self): return self.value.__int__()  # noqa: E704
-    def __long__(self): return self.value.__long__()  # noqa: E704
-    # def __hex__(self): return self.value.__hex__()  # noqa: E704
-    # def __oct__(self): return self.value.__oct__()  # noqa: E704
-    def __float__(self): return self.value.__float__()  # noqa: E704
-    # def __complex__(self): return self.value.__complex__()  # noqa: E704
+    def __round__(self, ndigits=None): return self.value.__round__(ndigits)  # noqa: E704
+
+    def __getitem__(self, idx):
+        return self.value.__getitem__(idx)
 
     def __jax_array__(self):
         return self.value
@@ -140,6 +138,9 @@ class BaseVar(abc.ABC):
     def __bool__(self):
         raise TypeError('To prevent accidental errors Objax variables can not be used as Python bool. '
                         'To check if variable is `None` use `is None` or `is not None` instead.')
+
+    def __getattr__(self, name):
+        return getattr(self.value, name)
 
     @property
     def dtype(self):
@@ -316,7 +317,7 @@ class VarCollection(Dict[str, BaseVar]):
         conflicts = set()
         for k, v in other:
             if k in self:
-                if self[k] != v:
+                if self[k] is not v:
                     conflicts.add(k)
             else:
                 self[k] = v

--- a/objax/variable.py
+++ b/objax/variable.py
@@ -29,7 +29,8 @@ from objax.util import map_to_device, Renamer, repr_function, class_name
 from objax.util.check import assert_assigned_type_and_shape_match
 
 
-def _get_jax_value(x):
+def get_jax_value(x: Union[JaxArray, 'BaseVar']):
+    """Returns JAX value encapsulated in the input argument."""
     if isinstance(x, BaseVar):
         return x.value
     else:
@@ -88,42 +89,42 @@ class BaseVar(abc.ABC):
     def __pos__(self): return self.value.__pos__()  # noqa: E704
     def __abs__(self): return self.value.__abs__()  # noqa: E704
     def __invert__(self): return self.value.__invert__()  # noqa: E704
-    def __eq__(self, other): return self.value.__eq__(_get_jax_value(other))  # noqa: E704
-    def __ne__(self, other): return self.value.__ne__(_get_jax_value(other))  # noqa: E704
-    def __lt__(self, other): return self.value.__lt__(_get_jax_value(other))  # noqa: E704
-    def __le__(self, other): return self.value.__le__(_get_jax_value(other))  # noqa: E704
-    def __gt__(self, other): return self.value.__gt__(_get_jax_value(other))  # noqa: E704
-    def __ge__(self, other): return self.value.__ge__(_get_jax_value(other))  # noqa: E704
-    def __add__(self, other): return self.value.__add__(_get_jax_value(other))  # noqa: E704
-    def __radd__(self, other): return self.value.__radd__(_get_jax_value(other))  # noqa: E704
-    def __sub__(self, other): return self.value.__sub__(_get_jax_value(other))  # noqa: E704
-    def __rsub__(self, other): return self.value.__rsub__(_get_jax_value(other))  # noqa: E704
-    def __mul__(self, other): return self.value.__mul__(_get_jax_value(other))  # noqa: E704
-    def __rmul__(self, other): return self.value.__rmul__(_get_jax_value(other))  # noqa: E704
-    def __div__(self, other): return self.value.__div__(_get_jax_value(other))  # noqa: E704
-    def __rdiv__(self, other): return self.value.__rdiv__(_get_jax_value(other))  # noqa: E704
-    def __truediv__(self, other): return self.value.__truediv__(_get_jax_value(other))  # noqa: E704
-    def __rtruediv__(self, other): return self.value.__rtruediv__(_get_jax_value(other))  # noqa: E704
-    def __floordiv__(self, other): return self.value.__floordiv__(_get_jax_value(other))  # noqa: E704
-    def __rfloordiv__(self, other): return self.value.__rfloordiv__(_get_jax_value(other))  # noqa: E704
-    def __divmod__(self, other): return self.value.__divmod__(_get_jax_value(other))  # noqa: E704
-    def __rdivmod__(self, other): return self.value.__rdivmod__(_get_jax_value(other))  # noqa: E704
-    def __mod__(self, other): return self.value.__mod__(_get_jax_value(other))  # noqa: E704
-    def __rmod__(self, other): return self.value.__rmod__(_get_jax_value(other))  # noqa: E704
-    def __pow__(self, other): return self.value.__pow__(_get_jax_value(other))  # noqa: E704
-    def __rpow__(self, other): return self.value.__rpow__(_get_jax_value(other))  # noqa: E704
-    def __matmul__(self, other): return self.value.__matmul__(_get_jax_value(other))  # noqa: E704
-    def __rmatmul__(self, other): return self.value.__rmatmul__(_get_jax_value(other))  # noqa: E704
-    def __and__(self, other): return self.value.__and__(_get_jax_value(other))  # noqa: E704
-    def __rand__(self, other): return self.value.__rand__(_get_jax_value(other))  # noqa: E704
-    def __or__(self, other): return self.value.__or__(_get_jax_value(other))  # noqa: E704
-    def __ror__(self, other): return self.value.__ror__(_get_jax_value(other))  # noqa: E704
-    def __xor__(self, other): return self.value.__xor__(_get_jax_value(other))  # noqa: E704
-    def __rxor__(self, other): return self.value.__rxor__(_get_jax_value(other))  # noqa: E704
-    def __lshift__(self, other): return self.value.__lshift__(_get_jax_value(other))  # noqa: E704
-    def __rlshift__(self, other): return self.value.__rlshift__(_get_jax_value(other))  # noqa: E704
-    def __rshift__(self, other): return self.value.__rshift__(_get_jax_value(other))  # noqa: E704
-    def __rrshift__(self, other): return self.value.__rrshift__(_get_jax_value(other))  # noqa: E704
+    def __eq__(self, other): return self.value.__eq__(get_jax_value(other))  # noqa: E704
+    def __ne__(self, other): return self.value.__ne__(get_jax_value(other))  # noqa: E704
+    def __lt__(self, other): return self.value.__lt__(get_jax_value(other))  # noqa: E704
+    def __le__(self, other): return self.value.__le__(get_jax_value(other))  # noqa: E704
+    def __gt__(self, other): return self.value.__gt__(get_jax_value(other))  # noqa: E704
+    def __ge__(self, other): return self.value.__ge__(get_jax_value(other))  # noqa: E704
+    def __add__(self, other): return self.value.__add__(get_jax_value(other))  # noqa: E704
+    def __radd__(self, other): return self.value.__radd__(get_jax_value(other))  # noqa: E704
+    def __sub__(self, other): return self.value.__sub__(get_jax_value(other))  # noqa: E704
+    def __rsub__(self, other): return self.value.__rsub__(get_jax_value(other))  # noqa: E704
+    def __mul__(self, other): return self.value.__mul__(get_jax_value(other))  # noqa: E704
+    def __rmul__(self, other): return self.value.__rmul__(get_jax_value(other))  # noqa: E704
+    def __div__(self, other): return self.value.__div__(get_jax_value(other))  # noqa: E704
+    def __rdiv__(self, other): return self.value.__rdiv__(get_jax_value(other))  # noqa: E704
+    def __truediv__(self, other): return self.value.__truediv__(get_jax_value(other))  # noqa: E704
+    def __rtruediv__(self, other): return self.value.__rtruediv__(get_jax_value(other))  # noqa: E704
+    def __floordiv__(self, other): return self.value.__floordiv__(get_jax_value(other))  # noqa: E704
+    def __rfloordiv__(self, other): return self.value.__rfloordiv__(get_jax_value(other))  # noqa: E704
+    def __divmod__(self, other): return self.value.__divmod__(get_jax_value(other))  # noqa: E704
+    def __rdivmod__(self, other): return self.value.__rdivmod__(get_jax_value(other))  # noqa: E704
+    def __mod__(self, other): return self.value.__mod__(get_jax_value(other))  # noqa: E704
+    def __rmod__(self, other): return self.value.__rmod__(get_jax_value(other))  # noqa: E704
+    def __pow__(self, other): return self.value.__pow__(get_jax_value(other))  # noqa: E704
+    def __rpow__(self, other): return self.value.__rpow__(get_jax_value(other))  # noqa: E704
+    def __matmul__(self, other): return self.value.__matmul__(get_jax_value(other))  # noqa: E704
+    def __rmatmul__(self, other): return self.value.__rmatmul__(get_jax_value(other))  # noqa: E704
+    def __and__(self, other): return self.value.__and__(get_jax_value(other))  # noqa: E704
+    def __rand__(self, other): return self.value.__rand__(get_jax_value(other))  # noqa: E704
+    def __or__(self, other): return self.value.__or__(get_jax_value(other))  # noqa: E704
+    def __ror__(self, other): return self.value.__ror__(get_jax_value(other))  # noqa: E704
+    def __xor__(self, other): return self.value.__xor__(get_jax_value(other))  # noqa: E704
+    def __rxor__(self, other): return self.value.__rxor__(get_jax_value(other))  # noqa: E704
+    def __lshift__(self, other): return self.value.__lshift__(get_jax_value(other))  # noqa: E704
+    def __rlshift__(self, other): return self.value.__rlshift__(get_jax_value(other))  # noqa: E704
+    def __rshift__(self, other): return self.value.__rshift__(get_jax_value(other))  # noqa: E704
+    def __rrshift__(self, other): return self.value.__rrshift__(get_jax_value(other))  # noqa: E704
     def __round__(self, ndigits=None): return self.value.__round__(ndigits)  # noqa: E704
 
     def __getitem__(self, idx):

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ scipy
 numpy>=1.18.0
 pillow
 jaxlib
-jax
+jax>=0.2.10
 tensorboard>=2.3.0
 parameterized

--- a/tests/jit.py
+++ b/tests/jit.py
@@ -27,7 +27,7 @@ class LinearArgs(objax.nn.Linear):
     def __call__(self, x: JaxArray, some_args: float) -> JaxArray:
         """Returns the results of applying the linear transformation to input x."""
         y = jn.dot(x, self.w.value) * some_args
-        if self.b:
+        if self.b is not None:
             y += self.b.value
         return y
 
@@ -38,7 +38,7 @@ class LinearTrain(objax.nn.Linear):
         y = jn.dot(x, self.w.value)
         if training:
             y = -y
-        if self.b:
+        if self.b is not None:
             y += self.b.value
         return y
 

--- a/tests/variable.py
+++ b/tests/variable.py
@@ -16,6 +16,7 @@
 
 import unittest
 
+import numpy as np
 import jax.numpy as jn
 
 import objax
@@ -137,6 +138,65 @@ class TestVariable(unittest.TestCase):
         with vc.replicate():
             self.assertEqual(len(vc['var'].value.shape), 2)
             self.assertEqual(vc['var'].value.shape[-1], 5)
+
+    def test_jax_duck_typing_jax_api_one_float_arg(self):
+        API_LIST = [
+            'abs', 'absolute', 'all', 'alltrue', 'amax', 'amin', 'any', 'arccos', 'arccosh', 'arcsin', 'arcsinh',
+            'arctan', 'arctanh', 'argmax', 'argmin', 'argsort', 'argwhere', 'around', 'asarray', 'average',
+            'cbrt', 'cdouble', 'ceil', 'complex128', 'complex64', 'conj', 'conjugate',
+            'corrcoef', 'cos', 'cosh', 'count_nonzero', 'csingle', 'cumprod', 'cumproduct', 'cumsum', 'deg2rad',
+            'degrees', 'diag', 'double', 'empty_like', 'exp', 'exp2', 'expm1', 'fabs', 'fix', 'flatnonzero', 'float16',
+            'float32', 'float64', 'floor', 'frexp', 'i0', 'int16', 'int32', 'int64', 'int8',
+            'iscomplex', 'iscomplexobj', 'isfinite', 'isinf', 'isnan', 'isneginf', 'isposinf', 'isreal', 'isrealobj',
+            'log', 'log10', 'log1p', 'log2', 'max', 'mean', 'median', 'min', 'modf', 'msort', 'nan_to_num',
+            'nanargmax', 'nanargmin', 'nancumprod', 'nancumsum', 'nanmedian', 'nanmax', 'nanmean', 'nanmin', 'nanprod',
+            'nanstd', 'nansum', 'nanvar', 'ndim', 'negative', 'nonzero', 'ones_like', 'positive', 'prod', 'product',
+            'ptp', 'rad2deg', 'radians', 'ravel', 'reciprocal', 'rint', 'round', 'shape', 'sign', 'signbit', 'sin',
+            'sinc', 'single', 'sinh', 'size', 'sometrue', 'sort', 'sort_complex', 'sqrt', 'square', 'squeeze', 'std',
+            'sum', 'tan', 'tanh', 'transpose', 'trunc', 'uint16', 'uint32', 'uint64', 'uint8', 'vander', 'var',
+            'zeros_like'
+        ]
+        v = objax.TrainVar(jn.array([1., 2., 3.], dtype=jn.float32))
+        for name in API_LIST:
+            fn = jn.__dict__[name]
+            expected = fn(v.value)
+            actual = fn(v)
+            np.testing.assert_allclose(expected, actual)
+
+    def test_jax_duck_typing_jax_api_two_float_arg(self):
+        API_LIST = [
+            'add', 'allclose', 'arctan2', 'array_equal', 'array_equiv', 'convolve', 'copysign', 'correlate', 'cross',
+            'divide', 'divmod', 'dot', 'equal', 'float_power', 'floor_divide', 'fmax', 'fmin', 'fmod', 'greater',
+            'greater_equal', 'heaviside', 'hypot', 'inner', 'isclose', 'kron', 'less', 'less_equal', 'logaddexp',
+            'logaddexp2', 'matmul', 'maximum', 'minimum', 'mod', 'multiply', 'nextafter', 'not_equal', 'outer',
+            'polyadd', 'polysub', 'power', 'remainder', 'searchsorted', 'subtract', 'true_divide'
+        ]
+        v1 = objax.TrainVar(jn.array([1., 2., 3.], dtype=jn.float32))
+        v2 = objax.TrainVar(jn.array([10., -20., 30.], dtype=jn.float32))
+        for name in API_LIST:
+            fn = jn.__dict__[name]
+            expected = fn(v1.value, v2.value)
+            actual = fn(v1, v2)
+            np.testing.assert_allclose(expected, actual)
+
+    def test_jax_duck_typing_jax_api_one_int_arg(self):
+        API_LIST = ['bincount', 'bitwise_not', 'invert', 'packbits']
+        v = objax.TrainVar(jn.array([1, 2, 3], dtype=jn.int32))
+        for name in API_LIST:
+            fn = jn.__dict__[name]
+            expected = fn(v.value)
+            actual = fn(v)
+            np.testing.assert_allclose(expected, actual)
+
+    def test_jax_duck_typing_jax_api_two_int_args(self):
+        API_LIST = ['bitwise_and', 'bitwise_or', 'bitwise_xor', 'gcd', 'lcm', 'ldexp', 'left_shift', 'right_shift']
+        v1 = objax.TrainVar(jn.array([1, 2, 3], dtype=jn.int32))
+        v2 = objax.TrainVar(jn.array([10, -20, 30], dtype=jn.int32))
+        for name in API_LIST:
+            fn = jn.__dict__[name]
+            expected = fn(v1.value, v2.value)
+            actual = fn(v1, v2)
+            np.testing.assert_allclose(expected, actual)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This is a prototype implementation of https://github.com/google/objax/issues/111

This is reasonably well tested and complete implementation of JAX duck typing, which allows to use Objax variables in mathematical expressions without explicitly calling `.value`.
This change does not include documentation, updates of examples, etc... which will be done in future pull requests.