### PR TITLE
Raised WARNINGS if input arguments dont have same shape 

### DIFF
--- a/objax/functional/loss.py
+++ b/objax/functional/loss.py
@@ -27,7 +27,7 @@ from objax.typing import JaxArray
 import warnings
 
 
-warn_mess = 'Argument shape mismatch in'
+WARN_SHAPE_MISMATCH = 'Argument shape mismatch in'
 
 
 def cross_entropy_logits(logits: JaxArray, labels: JaxArray) -> JaxArray:
@@ -40,8 +40,10 @@ def cross_entropy_logits(logits: JaxArray, labels: JaxArray) -> JaxArray:
     Returns:
         (batch, ...) tensor of the cross-entropies for each entry.
     """
+
+    FUNC_NAME = 'cross_entropy_logits'
     if logits.shape != labels.shape:
-        warnings.warn(' {} {} : arg1 {} and arg2 {}'.format(warn_mess, __all__[0], logits.shape, labels.shape))
+        warnings.warn(' {} {} : arg1 {} and arg2 {}'.format(WARN_SHAPE_MISMATCH, FUNC_NAME, logits.shape, labels.shape))
     return logsumexp(logits, axis=-1) - (logits * labels).sum(-1)
 
 
@@ -73,6 +75,7 @@ def l2(x: JaxArray) -> JaxArray:
     Returns:
         scalar tensor containing the l2 loss of x.
     """
+
     return 0.5 * (x ** 2).sum()
 
 
@@ -87,8 +90,10 @@ def mean_absolute_error(x: JaxArray, y: JaxArray, keep_axis: Optional[Iterable[i
     Returns:
         tensor of shape (d_i, ..., for i in keep_axis) containing the mean absolute error.
     """
+
+    FUNC_NAME = 'mean_absolute_error'
     if x.shape != y.shape:
-        warnings.warn(' {} {} : arg1 {} and arg2 {}'.format(warn_mess, __all__[3], x.shape, y.shape))
+        warnings.warn(' {} {} : arg1 {} and arg2 {}'.format(WARN_SHAPE_MISMATCH, FUNC_NAME, x.shape, y.shape))
     loss = jn.abs(x - y)
     axis = [i for i in range(loss.ndim) if i not in (keep_axis or ())]
     return loss.mean(axis)
@@ -105,8 +110,10 @@ def mean_squared_error(x: JaxArray, y: JaxArray, keep_axis: Optional[Iterable[in
     Returns:
         tensor of shape (d_i, ..., for i in keep_axis) containing the mean squared error.
     """
+
+    FUNC_NAME = 'mean_squared_error'
     if x.shape != y.shape:
-        warnings.warn(' {} {} : arg1 {} and arg2 {}'.format(warn_mess, __all__[4], x.shape, y.shape))
+        warnings.warn(' {} {} : arg1 {} and arg2 {}'.format(WARN_SHAPE_MISMATCH, FUNC_NAME, x.shape, y.shape))
     loss = (x - y) ** 2
     axis = [i for i in range(loss.ndim) if i not in (keep_axis or ())]
     return loss.mean(axis)
@@ -123,8 +130,10 @@ def mean_squared_log_error(y_true: JaxArray, y_pred: JaxArray, keep_axis: Option
     Returns:
         tensor of shape (d_i, ..., for i in keep_axis) containing the mean squared error.
     """
+
+    FUNC_NAME = 'mean_squared_log_error'
     if y_true.shape != y_pred.shape:
-        warnings.warn(' {} {} : arg1 {} and arg2 {}'.format(warn_mess, __all__[5], y_true.shape, y_pred.shape))
+        warnings.warn(' {} {} : arg1 {} and arg2 {}'.format(WARN_SHAPE_MISMATCH, FUNC_NAME, y_true.shape, y_pred.shape))
     loss = (jn.log1p(y_true) - jn.log1p(y_pred)) ** 2
     axis = [i for i in range(loss.ndim) if i not in (keep_axis or ())]
     return loss.mean(axis)
@@ -140,6 +149,8 @@ def sigmoid_cross_entropy_logits(logits: JaxArray, labels: Union[JaxArray, int])
     Returns:
         (batch, ...) tensor of the cross-entropies for each entry.
     """
+
+    FUNC_NAME = 'sigmoid_cross_entropy_logits'
     if logits.shape != labels.shape:
-        warnings.warn(' {} {} : arg1 {} and arg2 {}'.format(warn_mess, __all__[6], logits.shape, labels.shape))
+        warnings.warn(' {} {} : arg1 {} and arg2 {}'.format(WARN_SHAPE_MISMATCH, FUNC_NAME, logits.shape, labels.shape))
     return jn.maximum(logits, 0) - logits * labels + jn.log(1 + jn.exp(-jn.abs(logits)))

--- a/objax/functional/loss.py
+++ b/objax/functional/loss.py
@@ -28,6 +28,7 @@ from objax.functional.core import logsumexp
 from objax.typing import JaxArray
 import warnings
 
+
 def cross_entropy_logits(logits: JaxArray, labels: JaxArray) -> JaxArray:
     """Computes the softmax cross-entropy loss on n-dimensional data.
 
@@ -39,7 +40,7 @@ def cross_entropy_logits(logits: JaxArray, labels: JaxArray) -> JaxArray:
         (batch, ...) tensor of the cross-entropies for each entry.
     """
     if logits.shape != labels.shape:
-        warnings.warn('You are using input arguments with different shape: logits {} and labels {}'.format(logits.shape, labels.shape))
+        warnings.warn('Size Mismatch: logits {} and labels {}'.format(logits.shape, labels.shape))
 
     return logsumexp(logits, axis=-1) - (logits * labels).sum(-1)
 
@@ -54,9 +55,6 @@ def cross_entropy_logits_sparse(logits: JaxArray, labels: Union[JaxArray, int]) 
     Returns:
         (batch, ...) tensor of the cross-entropies for each entry.
     """
-
-    if logits.shape != labels.shape:
-        warnings.warn('You are using input arguments with different shape: logits {} and labels {}'.format(logits.shape, labels.shape))
 
     if isinstance(labels, int):
         labeled_logits = logits[..., labels]
@@ -75,8 +73,6 @@ def l2(x: JaxArray) -> JaxArray:
     Returns:
         scalar tensor containing the l2 loss of x.
     """
-
-    
     return 0.5 * (x ** 2).sum()
 
 
@@ -92,7 +88,7 @@ def mean_absolute_error(x: JaxArray, y: JaxArray, keep_axis: Optional[Iterable[i
         tensor of shape (d_i, ..., for i in keep_axis) containing the mean absolute error.
     """
     if x.shape != y.shape:
-        warnings.warn('You are using input arguments with different shape: x {} and y {}'.format(x.shape, y.shape))
+        warnings.warn('Size Mismatch: x {} and y {}'.format(x.shape, y.shape))
 
     loss = jn.abs(x - y)
     axis = [i for i in range(loss.ndim) if i not in (keep_axis or ())]
@@ -111,8 +107,8 @@ def mean_squared_error(x: JaxArray, y: JaxArray, keep_axis: Optional[Iterable[in
         tensor of shape (d_i, ..., for i in keep_axis) containing the mean squared error.
     """
     if x.shape != y.shape:
-        warnings.warn('You are using input arguments with different shape: x {} and y {}'.format(x.shape, y.shape))
-    
+        warnings.warn('Size Mismatch: x {} and y {}'.format(x.shape, y.shape))
+
     loss = (x - y) ** 2
     axis = [i for i in range(loss.ndim) if i not in (keep_axis or ())]
     return loss.mean(axis)
@@ -129,8 +125,8 @@ def mean_squared_log_error(y_true: JaxArray, y_pred: JaxArray, keep_axis: Option
     Returns:
         tensor of shape (d_i, ..., for i in keep_axis) containing the mean squared error.
     """
-    if  y_true.shape != y_pred.shape:
-        warnings.warn('You are using input arguments with different shape: logits {} and labels {}'.format(y_true.shape, y_pred.shape))
+    if y_true.shape != y_pred.shape:
+        warnings.warn('Size Mismatch: logits {} and labels {}'.format(y_true.shape, y_pred.shape))
 
     loss = (jn.log1p(y_true) - jn.log1p(y_pred)) ** 2
     axis = [i for i in range(loss.ndim) if i not in (keep_axis or ())]
@@ -147,7 +143,7 @@ def sigmoid_cross_entropy_logits(logits: JaxArray, labels: Union[JaxArray, int])
     Returns:
         (batch, ...) tensor of the cross-entropies for each entry.
     """
-    if  logits.shape != labels.shape:
-        warnings.warn('You are using input arguments with different shape: logits {} and labels {}'.format(logits.shape, labels.shape))
+    if logits.shape != labels.shape:
+        warnings.warn('Size Mismatch: logits {} and labels {}'.format(logits.shape, labels.shape))
 
     return jn.maximum(logits, 0) - logits * labels + jn.log(1 + jn.exp(-jn.abs(logits)))

--- a/objax/functional/loss.py
+++ b/objax/functional/loss.py
@@ -21,44 +21,15 @@ __all__ = ['cross_entropy_logits',
            'sigmoid_cross_entropy_logits']
 
 from typing import Union, Iterable, Optional
-
 import jax.numpy as jn
-
 from objax.functional.core import logsumexp
 from objax.typing import JaxArray
 import warnings
 
 
-def custom_formatwarning(msg, *args, **kwargs):
-    # ignore everything except the message
-    return str(msg) + '\n'
+warn_mess = 'Argument shape mismatch in'
 
 
-warnings.formatwarning = custom_formatwarning
-
-
-def sizemismatch_checker(func):
-    """Checks if the arguments of loss functions mismatch and returns a warning accordingly.
-
-    Args:
-        func: (function): loss_function
-
-    Returns:
-        (batch,...) tensor  result from the loss function.
-    """
-    mess = 'Arguments shape mismatch in'
-
-    def inner(arg1, arg2, *args, **kwargs):
-        if arg1.shape != arg2.shape:
-            warnings.warn(' {} {} : arg1 {} and arg2 {}'.format(mess, func.__name__, arg1.shape, arg2.shape))
-        returned_value = func(arg1, arg2, *args, **kwargs)
-
-        return returned_value
-
-    return inner
-
-
-@sizemismatch_checker
 def cross_entropy_logits(logits: JaxArray, labels: JaxArray) -> JaxArray:
     """Computes the softmax cross-entropy loss on n-dimensional data.
 
@@ -69,7 +40,8 @@ def cross_entropy_logits(logits: JaxArray, labels: JaxArray) -> JaxArray:
     Returns:
         (batch, ...) tensor of the cross-entropies for each entry.
     """
-
+    if logits.shape != labels.shape:
+        warnings.warn(' {} {} : arg1 {} and arg2 {}'.format(warn_mess, __all__[0], logits.shape, labels.shape))
     return logsumexp(logits, axis=-1) - (logits * labels).sum(-1)
 
 
@@ -104,7 +76,6 @@ def l2(x: JaxArray) -> JaxArray:
     return 0.5 * (x ** 2).sum()
 
 
-@sizemismatch_checker
 def mean_absolute_error(x: JaxArray, y: JaxArray, keep_axis: Optional[Iterable[int]] = (0,)) -> JaxArray:
     """Computes the mean absolute error between x and y.
 
@@ -116,12 +87,13 @@ def mean_absolute_error(x: JaxArray, y: JaxArray, keep_axis: Optional[Iterable[i
     Returns:
         tensor of shape (d_i, ..., for i in keep_axis) containing the mean absolute error.
     """
+    if x.shape != y.shape:
+        warnings.warn(' {} {} : arg1 {} and arg2 {}'.format(warn_mess, __all__[3], x.shape, y.shape))
     loss = jn.abs(x - y)
     axis = [i for i in range(loss.ndim) if i not in (keep_axis or ())]
     return loss.mean(axis)
 
 
-@sizemismatch_checker
 def mean_squared_error(x: JaxArray, y: JaxArray, keep_axis: Optional[Iterable[int]] = (0,)) -> JaxArray:
     """Computes the mean squared error between x and y.
 
@@ -133,12 +105,13 @@ def mean_squared_error(x: JaxArray, y: JaxArray, keep_axis: Optional[Iterable[in
     Returns:
         tensor of shape (d_i, ..., for i in keep_axis) containing the mean squared error.
     """
+    if x.shape != y.shape:
+        warnings.warn(' {} {} : arg1 {} and arg2 {}'.format(warn_mess, __all__[4], x.shape, y.shape))
     loss = (x - y) ** 2
     axis = [i for i in range(loss.ndim) if i not in (keep_axis or ())]
     return loss.mean(axis)
 
 
-@sizemismatch_checker
 def mean_squared_log_error(y_true: JaxArray, y_pred: JaxArray, keep_axis: Optional[Iterable[int]] = (0,)) -> JaxArray:
     """Computes the mean squared logarithmic error between y_true and y_pred.
 
@@ -150,12 +123,13 @@ def mean_squared_log_error(y_true: JaxArray, y_pred: JaxArray, keep_axis: Option
     Returns:
         tensor of shape (d_i, ..., for i in keep_axis) containing the mean squared error.
     """
+    if y_true.shape != y_pred.shape:
+        warnings.warn(' {} {} : arg1 {} and arg2 {}'.format(warn_mess, __all__[5], y_true.shape, y_pred.shape))
     loss = (jn.log1p(y_true) - jn.log1p(y_pred)) ** 2
     axis = [i for i in range(loss.ndim) if i not in (keep_axis or ())]
     return loss.mean(axis)
 
 
-@sizemismatch_checker
 def sigmoid_cross_entropy_logits(logits: JaxArray, labels: Union[JaxArray, int]) -> JaxArray:
     """Computes the sigmoid cross-entropy loss.
 
@@ -166,4 +140,6 @@ def sigmoid_cross_entropy_logits(logits: JaxArray, labels: Union[JaxArray, int])
     Returns:
         (batch, ...) tensor of the cross-entropies for each entry.
     """
+    if logits.shape != labels.shape:
+        warnings.warn(' {} {} : arg1 {} and arg2 {}'.format(warn_mess, __all__[6], logits.shape, labels.shape))
     return jn.maximum(logits, 0) - logits * labels + jn.log(1 + jn.exp(-jn.abs(logits)))

--- a/objax/functional/loss.py
+++ b/objax/functional/loss.py
@@ -26,7 +26,7 @@ import jax.numpy as jn
 
 from objax.functional.core import logsumexp
 from objax.typing import JaxArray
-
+import warnings
 
 def cross_entropy_logits(logits: JaxArray, labels: JaxArray) -> JaxArray:
     """Computes the softmax cross-entropy loss on n-dimensional data.
@@ -38,6 +38,9 @@ def cross_entropy_logits(logits: JaxArray, labels: JaxArray) -> JaxArray:
     Returns:
         (batch, ...) tensor of the cross-entropies for each entry.
     """
+    if logits.shape != labels.shape:
+        warnings.warn('You are using input arguments with different shape: logits {} and labels {}'.format(logits.shape, labels.shape))
+
     return logsumexp(logits, axis=-1) - (logits * labels).sum(-1)
 
 
@@ -51,6 +54,10 @@ def cross_entropy_logits_sparse(logits: JaxArray, labels: Union[JaxArray, int]) 
     Returns:
         (batch, ...) tensor of the cross-entropies for each entry.
     """
+
+    if logits.shape != labels.shape:
+        warnings.warn('You are using input arguments with different shape: logits {} and labels {}'.format(logits.shape, labels.shape))
+
     if isinstance(labels, int):
         labeled_logits = logits[..., labels]
     else:
@@ -68,6 +75,8 @@ def l2(x: JaxArray) -> JaxArray:
     Returns:
         scalar tensor containing the l2 loss of x.
     """
+
+    
     return 0.5 * (x ** 2).sum()
 
 
@@ -82,6 +91,9 @@ def mean_absolute_error(x: JaxArray, y: JaxArray, keep_axis: Optional[Iterable[i
     Returns:
         tensor of shape (d_i, ..., for i in keep_axis) containing the mean absolute error.
     """
+    if x.shape != y.shape:
+        warnings.warn('You are using input arguments with different shape: x {} and y {}'.format(x.shape, y.shape))
+
     loss = jn.abs(x - y)
     axis = [i for i in range(loss.ndim) if i not in (keep_axis or ())]
     return loss.mean(axis)
@@ -98,6 +110,9 @@ def mean_squared_error(x: JaxArray, y: JaxArray, keep_axis: Optional[Iterable[in
     Returns:
         tensor of shape (d_i, ..., for i in keep_axis) containing the mean squared error.
     """
+    if x.shape != y.shape:
+        warnings.warn('You are using input arguments with different shape: x {} and y {}'.format(x.shape, y.shape))
+    
     loss = (x - y) ** 2
     axis = [i for i in range(loss.ndim) if i not in (keep_axis or ())]
     return loss.mean(axis)
@@ -114,6 +129,9 @@ def mean_squared_log_error(y_true: JaxArray, y_pred: JaxArray, keep_axis: Option
     Returns:
         tensor of shape (d_i, ..., for i in keep_axis) containing the mean squared error.
     """
+    if  y_true.shape != y_pred.shape:
+        warnings.warn('You are using input arguments with different shape: logits {} and labels {}'.format(y_true.shape, y_pred.shape))
+
     loss = (jn.log1p(y_true) - jn.log1p(y_pred)) ** 2
     axis = [i for i in range(loss.ndim) if i not in (keep_axis or ())]
     return loss.mean(axis)
@@ -129,4 +147,7 @@ def sigmoid_cross_entropy_logits(logits: JaxArray, labels: Union[JaxArray, int])
     Returns:
         (batch, ...) tensor of the cross-entropies for each entry.
     """
+    if  logits.shape != labels.shape:
+        warnings.warn('You are using input arguments with different shape: logits {} and labels {}'.format(logits.shape, labels.shape))
+
     return jn.maximum(logits, 0) - logits * labels + jn.log(1 + jn.exp(-jn.abs(logits)))


### PR DESCRIPTION
Related to Issue #190. I have included warning checkpoints only to those functions that doesn't raise error by default in order to avoid unnecessary warnings.  