### PR TITLE
Fix jax index update in the tutorial

### DIFF
--- a/docs/source/notebooks/Objax_Basics.ipynb
+++ b/docs/source/notebooks/Objax_Basics.ipynb
@@ -612,7 +612,7 @@
       },
       "source": [
         "Instead of updating an existing tensor, a new tensor should be created with updated elements. Updates of individual tensor elements is done using\n",
-        "[index_update](https://jax.readthedocs.io/en/latest/_autosummary/jax.ops.index_update.html#jax.ops.index_update), [index_add](https://jax.readthedocs.io/en/latest/_autosummary/jax.ops.index_add.html#jax.ops.index_add) and some other JAX primitives:"
+        "the [at](https://jax.readthedocs.io/en/latest/_autosummary/jax.numpy.ndarray.at.html) property:"
       ]
     },
     {
@@ -640,7 +640,7 @@
         "import jax.ops\n",
         "\n",
         "print('Original tensor t:\\n', t)\n",
-        "new_t = jax.ops.index_update(t, jax.ops.index[0, 0], -5.0)\n",
+        "new_t = t.at[0,0].set(-5.0)\n",
         "print('Tensor t after update stays the same:\\n', t)\n",
         "print('Tensor new_t has updated value:\\n', new_t)"
       ],


### PR DESCRIPTION
See https://jax.readthedocs.io/en/latest/changelog.html#jax-0-3-2-march-16-2022
The functions `jax.ops.index_update`, `jax.ops.index_add`, which were deprecated in 0.2.22, have been removed. 
